### PR TITLE
Fix `make lint` Command

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -146,6 +146,7 @@
               pkgs'.cabal-install
               pkgs'.hlint
               pkgs'.haskellPackages.cabal-fmt
+              pkgs'.haskellPackages.apply-refact
               (fourmoluFor system)
               pkgs'.nixpkgs-fmt
               (plutarch.hlsFor compiler-nix-name system)

--- a/shell.nix
+++ b/shell.nix
@@ -32,6 +32,7 @@ with import ./nix { };
       cabal-install
       haskellPackages.fourmolu
       haskellPackages.cabal-fmt
+      haskellPackages.apply-refact
       fd
       entr
       git


### PR DESCRIPTION
Currently on `main`, `make lint` yields the following error:

```
CallStack (from HasCallStack):
  errorIO, called at src/Refact.hs:43:41 in hlint-3.3.6-F2dKao436yaKIqpUYwfMGH:Refact
hlint: Could not find 'refactor' executable
Tried to find 'refactor' on the PATH
'refactor' is provided by the 'apply-refact' package and has to be installed
<https://github.com/mpickering/apply-refact>
```

This pr fixes the issue by adding `apply-refact` to flake.