### PR TITLE
Upstream some utils from Agora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ watch: requires_nix_shell
 
 
 test: requires_nix_shell
-	cabal v2-test
+	cabal v2-test --test-options="--quickcheck-tests 10_000"
 
 ghci: requires_nix_shell
 	cabal v2-repl $(GHC_FLAGS) liqwid-plutarch-extra

--- a/flake.lock
+++ b/flake.lock
@@ -1892,17 +1892,17 @@
         "plutarch": "plutarch_2"
       },
       "locked": {
-        "lastModified": 1654293728,
-        "narHash": "sha256-6Pd410I03CetLM4YYrJmMldOYDyqGPATlmorhKKWU0Q=",
+        "lastModified": 1655113586,
+        "narHash": "sha256-hv9tzB3IGvga6/SBDnk16S3Sfp03tvtkWd8COW0It30=",
         "owner": "liqwid-labs",
         "repo": "plutarch-quickcheck",
-        "rev": "cd7df08176e0ee5111980ead903764979d920147",
+        "rev": "a560e12b4809c0f292c96e81189e1b2cf2e7f7eb",
         "type": "github"
       },
       "original": {
         "owner": "liqwid-labs",
-        "ref": "staging",
         "repo": "plutarch-quickcheck",
+        "rev": "a560e12b4809c0f292c96e81189e1b2cf2e7f7eb",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
   inputs.haskell-language-server.url = "github:haskell/haskell-language-server";
   inputs.haskell-language-server.flake = false;
 
-  inputs.plutarch-quickcheck.url = "github:liqwid-labs/plutarch-quickcheck?ref=staging";
+  inputs.plutarch-quickcheck.url = "github:liqwid-labs/plutarch-quickcheck?rev=a560e12b4809c0f292c96e81189e1b2cf2e7f7eb";
 
   outputs = inputs@{ self, nixpkgs, nixpkgs-latest, haskell-nix, plutarch, ... }:
     let

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -107,17 +107,25 @@ test-suite liqwid-plutarch-extra-test
   main-is:        Spec.hs
   ghc-options:    -O2 -threaded -rtsopts -with-rtsopts=-N
   build-depends:
+    , bytestring
     , containers
     , liqwid-plutarch-extra
     , mtl
     , plutarch-quickcheck
+    , plutus-core
     , QuickCheck
     , quickcheck-instances
     , tasty
     , tasty-quickcheck
+    , universe
 
   other-modules:
+    Spec.Api.V1.Value
+    Spec.Api.V1.Value.Unsorted
     Spec.Extra.List
     Spec.Extra.Map
+    Spec.Extra.Map.Sorted
+    Spec.Extra.Map.Unsorted
+    Spec.Utils
 
   hs-source-dirs: test

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -85,6 +85,7 @@ library
     Plutarch.Extra.State
     Plutarch.Extra.Sum
     Plutarch.Extra.Tagged
+    Plutarch.Extra.TermCont
     Plutarch.Extra.These
     Plutarch.Extra.Traversable
 

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -70,6 +70,7 @@ library
     Plutarch.Api.V1.AssetClass
     Plutarch.Api.V1.ScriptContext
     Plutarch.Api.V1.Value
+    Plutarch.Api.V1.Value.Unsorted
     Plutarch.Extra.Applicative
     Plutarch.Extra.Bool
     Plutarch.Extra.Category
@@ -80,6 +81,8 @@ library
     Plutarch.Extra.Identity
     Plutarch.Extra.List
     Plutarch.Extra.Map
+    Plutarch.Extra.Map.Sorted
+    Plutarch.Extra.Map.Unsorted
     Plutarch.Extra.Maybe
     Plutarch.Extra.Numeric
     Plutarch.Extra.Profunctor

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -31,8 +31,9 @@ common common-lang
     -Wno-partial-type-signatures
 
   build-depends:
-    , base      ^>=4.16
+    , base       ^>=4.16
     , plutarch
+    , plutus-tx
 
   default-extensions:
     BangPatterns
@@ -92,7 +93,6 @@ library
   build-depends:
     , generics-sop
     , plutarch-extra
-    , plutus-tx
     , tagged
 
   hs-source-dirs:  src
@@ -112,5 +112,8 @@ test-suite liqwid-plutarch-extra-test
     , tasty
     , tasty-quickcheck
 
-  other-modules:  Spec.Extra.List
+  other-modules:
+    Spec.Extra.List
+    Spec.Extra.Map
+
   hs-source-dirs: test

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            1.0.0
+version:            1.1.0
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -28,11 +28,11 @@ common common-lang
     -Wall -Wcompat -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Wredundant-constraints
     -Wmissing-export-lists -Wmissing-deriving-strategies -Werror
+    -Wno-partial-type-signatures
 
   build-depends:
-    , base            ^>=4.16
+    , base      ^>=4.16
     , plutarch
-    , plutarch-extra
 
   default-extensions:
     BangPatterns
@@ -52,6 +52,7 @@ common common-lang
     MultiParamTypeClasses
     NumericUnderscores
     OverloadedStrings
+    PackageImports
     ScopedTypeVariables
     StandaloneDeriving
     TupleSections
@@ -75,6 +76,7 @@ library
     Plutarch.Extra.Function
     Plutarch.Extra.Functor
     Plutarch.Extra.Identity
+    Plutarch.Extra.List
     Plutarch.Extra.Map
     Plutarch.Extra.Maybe
     Plutarch.Extra.Numeric
@@ -88,6 +90,7 @@ library
 
   build-depends:
     , generics-sop
+    , plutarch-extra
     , plutus-tx
     , tagged
 
@@ -99,11 +102,14 @@ test-suite liqwid-plutarch-extra-test
   main-is:        Spec.hs
   ghc-options:    -O2 -threaded -rtsopts -with-rtsopts=-N
   build-depends:
+    , containers
     , liqwid-plutarch-extra
+    , mtl
     , plutarch-quickcheck
     , QuickCheck
     , quickcheck-instances
     , tasty
     , tasty-quickcheck
 
+  other-modules:  Spec.Extra.List
   hs-source-dirs: test

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -31,8 +31,9 @@ common common-lang
     -Wno-partial-type-signatures
 
   build-depends:
-    , base       ^>=4.16
+    , base               ^>=4.16
     , plutarch
+    , plutus-ledger-api
     , plutus-tx
 
   default-extensions:

--- a/src/Plutarch/Api/V1/ScriptContext.hs
+++ b/src/Plutarch/Api/V1/ScriptContext.hs
@@ -96,7 +96,7 @@ pownInput = phoistAcyclic $
 
 {- | Determines if a given UTXO is spent.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pisUTXOSpent :: Term s (PTxOutRef :--> PBuiltinList (PAsData PTxInInfo) :--> PBool)
 pisUTXOSpent = phoistAcyclic $
@@ -104,7 +104,7 @@ pisUTXOSpent = phoistAcyclic $
 
 {- | Sum of all value at input.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pvalueSpent ::
     forall (s :: S).
@@ -131,7 +131,7 @@ pvalueSpent = phoistAcyclic $
      When using this as an authority check, you __MUST__ ensure the authority
      knows how to ensure its end of the contract.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pisTokenSpent :: forall {s :: S}. Term s (PAssetClass :--> PBuiltinList (PAsData PTxInInfo) :--> PBool)
 pisTokenSpent =
@@ -150,7 +150,7 @@ pisTokenSpent =
 
 {- | Find the TxInInfo by a TxOutRef.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pfindTxInByTxOutRef :: Term s (PTxOutRef :--> PBuiltinList (PAsData PTxInInfo) :--> PMaybe PTxInInfo)
 pfindTxInByTxOutRef = phoistAcyclic $
@@ -169,7 +169,7 @@ pfindTxInByTxOutRef = phoistAcyclic $
 
 {- | Check if a PubKeyHash signs this transaction.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 ptxSignedBy :: Term s (PBuiltinList (PAsData PPubKeyHash) :--> PAsData PPubKeyHash :--> PBool)
 ptxSignedBy = phoistAcyclic $
@@ -177,7 +177,7 @@ ptxSignedBy = phoistAcyclic $
 
 {- | Find a datum with the given hash.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pfindDatum :: Term s (PDatumHash :--> PBuiltinList (PAsData (PTuple PDatumHash PDatum)) :--> PMaybe PDatum)
 pfindDatum = phoistAcyclic $
@@ -185,7 +185,7 @@ pfindDatum = phoistAcyclic $
 
 {- | Find a datum with the given hash, and `ptryFrom` it.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 ptryFindDatum ::
     forall (a :: S -> Type) (s :: S).

--- a/src/Plutarch/Api/V1/ScriptContext.hs
+++ b/src/Plutarch/Api/V1/ScriptContext.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Plutarch.Api.V1.ScriptContext (
@@ -6,26 +7,45 @@ module Plutarch.Api.V1.ScriptContext (
     pownValue,
     pownMintValue,
     pownInput,
+    pisTokenSpent,
+    pisUTXOSpent,
+    pvalueSpent,
+    ptxSignedBy,
+    ptryFindDatum,
+    pfindDatum,
+    pfindTxInByTxOutRef,
 ) where
 
-import Plutarch (S, Term, phoistAcyclic, plam, unTermCont, (#), (:-->))
+import Data.Kind (Type)
+import Plutarch (PCon (..), S, Term, phoistAcyclic, plam, plet, pmatch, pto, unTermCont, (#), (#$), (:-->))
 import Plutarch.Api.V1 (
-    AmountGuarantees (NoGuarantees, Positive),
-    KeyGuarantees (Sorted),
+    AmountGuarantees (..),
+    KeyGuarantees (..),
+    PDatum,
+    PDatumHash,
+    PPubKeyHash,
     PScriptContext,
     PScriptPurpose (PSpending),
-    PTxInInfo,
+    PTuple,
+    PTxInInfo (..),
     PTxInfo,
+    PTxOut (..),
     PTxOutRef,
     PValue,
  )
-import Plutarch.Bool (PBool, (#==))
-import Plutarch.Builtin (PAsData, pfromData)
+import Plutarch.Api.V1.AssetClass (PAssetClass (..), passetClassValueOf)
+import Plutarch.Bool (PBool, POrd (..), pif, (#==))
+import Plutarch.Builtin (PAsData, PBuiltinList, PData, pdata, pfromData)
 import Plutarch.DataRepr (pfield)
-import Plutarch.Extra.TermCont (pletC, pmatchC)
-import Plutarch.List (pfind)
+import Plutarch.Extra.List (pfirstJust, plookupTuple)
+import Plutarch.Extra.Maybe (pisJust)
+import Plutarch.Extra.TermCont (pletC, pmatchC, ptryFromC)
+import Plutarch.Lift (pconstant)
+import Plutarch.List (pelem, pfind, pfoldr)
 import Plutarch.Maybe (PMaybe (PJust, PNothing))
 import Plutarch.Trace (ptraceError)
+import Plutarch.TryFrom (PTryFrom)
+import Plutarch.Unsafe (punsafeCoerce)
 
 pownTxOutRef ::
     forall (s :: S).
@@ -73,3 +93,108 @@ pownInput = phoistAcyclic $
         plam $ \tgt t -> unTermCont $ do
             x <- pletC (pfield @"outRef" # pfromData t)
             pure $ tgt #== x
+
+{- | Determines if a given UTXO is spent.
+
+    @since 1.0.0
+-}
+pisUTXOSpent :: Term s (PTxOutRef :--> PBuiltinList (PAsData PTxInInfo) :--> PBool)
+pisUTXOSpent = phoistAcyclic $
+    plam $ \oref inputs -> pisJust #$ pfindTxInByTxOutRef # oref # inputs
+
+{- | Sum of all value at input.
+
+    @since 1.0.0
+-}
+pvalueSpent ::
+    forall (s :: S).
+    Term s (PBuiltinList (PAsData PTxInInfo) :--> PValue 'Sorted 'Positive)
+pvalueSpent = phoistAcyclic $
+    plam $ \inputs ->
+        pfoldr
+            # plam
+                ( \txInInfo' v ->
+                    pmatch
+                        (pfromData txInInfo')
+                        $ \(PTxInInfo txInInfo) ->
+                            pmatch
+                                (pfield @"resolved" # txInInfo)
+                                (\(PTxOut o) -> pfromData $ pfield @"value" # o)
+                                <> v
+                )
+            -- TODO: This should be possible without coercions, but I can't figure out the types atm.
+            # punsafeCoerce (pconstant mempty :: Term _ (PValue 'Unsorted 'NonZero))
+            # inputs
+
+{- | Check if a particular asset class has been spent in the input list.
+
+     When using this as an authority check, you __MUST__ ensure the authority
+     knows how to ensure its end of the contract.
+
+    @since 1.0.0
+-}
+pisTokenSpent :: forall {s :: S}. Term s (PAssetClass :--> PBuiltinList (PAsData PTxInInfo) :--> PBool)
+pisTokenSpent =
+    plam $ \tokenClass inputs ->
+        0
+            #< pfoldr @PBuiltinList
+                # plam
+                    ( \txInInfo' acc -> unTermCont $ do
+                        PTxInInfo txInInfo <- pmatchC (pfromData txInInfo')
+                        PTxOut txOut' <- pmatchC $ pfromData $ pfield @"resolved" # txInInfo
+                        let value = pfromData $ pfield @"value" # txOut'
+                        pure $ acc + passetClassValueOf # value # tokenClass
+                    )
+                # 0
+                # inputs
+
+{- | Find the TxInInfo by a TxOutRef.
+
+    @since 1.0.0
+-}
+pfindTxInByTxOutRef :: Term s (PTxOutRef :--> PBuiltinList (PAsData PTxInInfo) :--> PMaybe PTxInInfo)
+pfindTxInByTxOutRef = phoistAcyclic $
+    plam $ \txOutRef inputs ->
+        pfirstJust
+            # plam
+                ( \txInInfo' ->
+                    plet (pfromData txInInfo') $ \r ->
+                        pmatch r $ \(PTxInInfo txInInfo) ->
+                            pif
+                                (pdata txOutRef #== pfield @"outRef" # txInInfo)
+                                (pcon (PJust r))
+                                (pcon PNothing)
+                )
+            #$ inputs
+
+{- | Check if a PubKeyHash signs this transaction.
+
+    @since 1.0.0
+-}
+ptxSignedBy :: Term s (PBuiltinList (PAsData PPubKeyHash) :--> PAsData PPubKeyHash :--> PBool)
+ptxSignedBy = phoistAcyclic $
+    plam $ \sigs sig -> pelem # sig # sigs
+
+{- | Find a datum with the given hash.
+
+    @since 1.0.0
+-}
+pfindDatum :: Term s (PDatumHash :--> PBuiltinList (PAsData (PTuple PDatumHash PDatum)) :--> PMaybe PDatum)
+pfindDatum = phoistAcyclic $
+    plam $ \datumHash datums -> plookupTuple # datumHash # datums
+
+{- | Find a datum with the given hash, and `ptryFrom` it.
+
+    @since 1.0.0
+-}
+ptryFindDatum ::
+    forall (a :: S -> Type) (s :: S).
+    PTryFrom PData a =>
+    Term s (PDatumHash :--> PBuiltinList (PAsData (PTuple PDatumHash PDatum)) :--> PMaybe a)
+ptryFindDatum = phoistAcyclic $
+    plam $ \datumHash inputs ->
+        pmatch (pfindDatum # datumHash # inputs) $ \case
+            PNothing -> pcon PNothing
+            PJust datum -> unTermCont $ do
+                (datum', _) <- ptryFromC (pto datum)
+                pure $ pcon (PJust datum')

--- a/src/Plutarch/Api/V1/Value.hs
+++ b/src/Plutarch/Api/V1/Value.hs
@@ -104,7 +104,7 @@ padaOf = phoistAcyclic $ plam $ \v -> pvalueOf # v # pconstant "" # pconstant ""
 
 {- | Get the sum of all values belonging to a particular CurrencySymbol.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 psymbolValueOf ::
     forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).
@@ -120,7 +120,7 @@ psymbolValueOf =
 
 {- | Extract amount from PValue belonging to a Haskell-level AssetClass.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 passetClassValueOf' ::
     forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).
@@ -131,7 +131,7 @@ passetClassValueOf' (AssetClass (sym, token)) =
 
 {- | Return '>=' on two values comparing by only a particular AssetClass.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 pgeqByClass ::
     forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).
@@ -143,7 +143,7 @@ pgeqByClass =
 
 {- | Return '>=' on two values comparing by only a particular CurrencySymbol.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 pgeqBySymbol ::
     forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).
@@ -155,7 +155,7 @@ pgeqBySymbol =
 
 {- | Return '>=' on two values comparing by only a particular Haskell-level AssetClass.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 pgeqByClass' ::
     forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).
@@ -168,7 +168,7 @@ pgeqByClass' ac =
 
 {- | Compute the guarantees known after adding two values.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 type family AddGuarantees (a :: AmountGuarantees) (b :: AmountGuarantees) where
     AddGuarantees 'Positive 'Positive = 'Positive

--- a/src/Plutarch/Api/V1/Value/Unsorted.hs
+++ b/src/Plutarch/Api/V1/Value/Unsorted.hs
@@ -20,7 +20,7 @@ import qualified Plutarch.Extra.Map.Unsorted as UnsortedMap
 
 {- | / O(n^2*logn) /. Sort a 'PValue'.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 psort ::
     forall (a :: AmountGuarantees) (s :: S).

--- a/src/Plutarch/Api/V1/Value/Unsorted.hs
+++ b/src/Plutarch/Api/V1/Value/Unsorted.hs
@@ -1,0 +1,33 @@
+module Plutarch.Api.V1.Value.Unsorted (psort) where
+
+import Plutarch (
+    PMatch (pmatch),
+    S,
+    Term,
+    pcon,
+    phoistAcyclic,
+    plam,
+    (#),
+    type (:-->),
+ )
+import Plutarch.Api.V1 (
+    AmountGuarantees (..),
+    KeyGuarantees (..),
+    PValue (PValue),
+ )
+import qualified Plutarch.Extra.Map as Map
+import qualified Plutarch.Extra.Map.Unsorted as UnsortedMap
+
+{- | / O(n^2*logn) /. Sort a 'PValue'.
+
+   @since 1.0.0
+-}
+psort ::
+    forall (a :: AmountGuarantees) (s :: S).
+    Term s (PValue 'Unsorted a :--> PValue 'Sorted a)
+psort = phoistAcyclic $
+    plam $ \v -> pmatch v $ \case
+        (PValue m) ->
+            let m' = Map.pmap # UnsortedMap.psort # m
+                m'' = UnsortedMap.psort # m'
+             in pcon $ PValue m''

--- a/src/Plutarch/Extra/List.hs
+++ b/src/Plutarch/Extra/List.hs
@@ -253,7 +253,7 @@ pmapMaybe = phoistAcyclic $
 
 {- | Get the first element that matches a predicate or return Nothing.
 
-     @since 1.0.0
+     @since 1.1.0
 -}
 pfind' ::
     forall (a :: S -> Type) (s :: S) list.

--- a/src/Plutarch/Extra/List.hs
+++ b/src/Plutarch/Extra/List.hs
@@ -51,7 +51,7 @@ import Prelude hiding (last)
 
 {- | True if a list is not empty.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 pnotNull ::
     forall (a :: S -> Type) (s :: S) list.
@@ -67,7 +67,7 @@ pnotNull =
 {- | / O(n) /. Merge two lists which are assumed to be ordered, given a custom comparator.
     The comparator should return true if first value is less than the second one.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 pmergeBy ::
     forall (a :: S -> Type) (s :: S) list.
@@ -102,7 +102,7 @@ pmergeBy = phoistAcyclic $ pfix #$ plam go
     the list elements will be arranged in ascending order, keeping duplicates in the order
     they appeared in the input.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 pmsortBy ::
     forall s a l.
@@ -133,7 +133,7 @@ pmsortBy = phoistAcyclic $
 
 {- | A special case of 'pmsortBy' which requires elements have 'POrd' instance.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 pmsort ::
     (POrd a, PIsListLike l a, PIsListLike l (l a)) =>
@@ -147,7 +147,7 @@ pmsort = phoistAcyclic $ pmsortBy # comp
     The first parameter is a equalator, which should return true if the two given values are equal.
     The second parameter is a comparator, which should returns true if the first value is less than the second value.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pnubSortBy ::
     forall (a :: S -> Type) (s :: S) list.
@@ -184,7 +184,7 @@ pnubSortBy = phoistAcyclic $
 
 {- | Special version of 'pnubSortBy', which requires elements have 'POrd' instance.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 pnubSort ::
     forall (a :: S -> Type) (s :: S) list.
@@ -216,7 +216,7 @@ pisUniqBy = phoistAcyclic $
 
 {- | A special case of 'pisUniqBy' which requires elements have 'POrd' instance.
 
-   @since 1.0.0
+   @since 1.1.0
 -}
 pisUniq ::
     forall (a :: S -> Type) (s :: S) list.
@@ -229,7 +229,7 @@ pisUniq = phoistAcyclic $ pisUniqBy # eq # comp
 
 {- | A special version of `pmap` which allows list elements to be thrown out.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pmapMaybe ::
     forall (a :: S -> Type) (s :: S) list.
@@ -267,7 +267,7 @@ pfind' p =
 
 {- | Get the first element that maps to a 'PJust' in a list.
 
-     @since 1.0.0
+     @since 1.1.0
 -}
 pfirstJust ::
     forall (a :: S -> Type) (b :: S -> Type) (s :: S) list.
@@ -287,7 +287,7 @@ pfirstJust =
 
 {- | /O(n)/. Find the value for a given key in an associative list.
 
-     @since 1.0.0
+     @since 1.1.0
 -}
 plookup ::
     forall (a :: S -> Type) (b :: S -> Type) (s :: S) list.
@@ -302,7 +302,7 @@ plookup =
 
 {- | /O(n)/. Find the value for a given key in an assoclist which uses 'PTuple's.
 
-     @since 1.0.0
+     @since 1.1.0
 -}
 plookupTuple ::
     (PEq a, PIsListLike list (PAsData (PTuple a b)), PIsData a, PIsData b) =>
@@ -314,6 +314,10 @@ plookupTuple =
                 PNothing -> pcon PNothing
                 PJust p -> pcon (PJust (pfield @"_1" # pfromData p))
 
+{- | O(n). Returns true if the given list is sorted.
+
+     @since 1.1.0
+-}
 pisSortedBy ::
     (PIsListLike list a) =>
     Term s ((a :--> a :--> PBool) :--> (a :--> a :--> PBool) :--> list a :--> PBool)
@@ -335,6 +339,10 @@ pisSortedBy = phoistAcyclic $
                         (self # x' #$ ptail # xs)
                         (pconstant False)
 
+{- | Special version of 'pisSortedBy'.
+
+     @since 1.1.0
+-}
 pisSorted ::
     (PIsListLike list a, POrd a) =>
     Term s (list a :--> PBool)

--- a/src/Plutarch/Extra/List.hs
+++ b/src/Plutarch/Extra/List.hs
@@ -17,6 +17,7 @@ module Plutarch.Extra.List (
     pbinarySearchBy,
     pbinarySearch,
     plookupTuple,
+    module Extra,
 ) where
 
 import Data.Kind (Type)
@@ -38,6 +39,10 @@ import Plutarch.Api.V1.Tuple (PTuple)
 import Plutarch.Bool (PBool (..), PEq (..), POrd (..), pif)
 import Plutarch.Builtin (PAsData, PBuiltinPair, PIsData, pfromData, pfstBuiltin, psndBuiltin)
 import Plutarch.DataRepr (pfield)
+import "plutarch-extra" Plutarch.Extra.List as Extra (
+    pcheckSorted,
+    preverse,
+ )
 import Plutarch.Extra.TermCont (pletC)
 import Plutarch.List (PIsListLike, PListLike (..), plength, precList, psingleton)
 import Plutarch.Maybe (PMaybe (PJust, PNothing))

--- a/src/Plutarch/Extra/List.hs
+++ b/src/Plutarch/Extra/List.hs
@@ -1,0 +1,402 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Plutarch.Extra.List (
+    pnotNull,
+    pmergeBy,
+    phalve,
+    pmsortBy,
+    pmsort,
+    pnubSortBy,
+    pnubSort,
+    pisUniqBy,
+    pisUniq,
+    pmapMaybe,
+    pfind',
+    pfirstJust,
+    plookup,
+    pbinarySearchBy,
+    pbinarySearch,
+    plookupTuple,
+) where
+
+import Data.Kind (Type)
+import Plutarch (
+    PCon (pcon),
+    PMatch (pmatch),
+    S,
+    Term,
+    pfix,
+    phoistAcyclic,
+    plam,
+    plet,
+    unTermCont,
+    (#),
+    (#$),
+    type (:-->),
+ )
+import Plutarch.Api.V1.Tuple (PTuple)
+import Plutarch.Bool (PBool (..), PEq (..), POrd (..), pif)
+import Plutarch.Builtin (PAsData, PBuiltinPair, PIsData, pfromData, pfstBuiltin, psndBuiltin)
+import Plutarch.DataRepr (pfield)
+import Plutarch.Extra.TermCont (pletC)
+import Plutarch.List (PIsListLike, PListLike (..), plength, precList, psingleton)
+import Plutarch.Maybe (PMaybe (PJust, PNothing))
+import Plutarch.Pair (PPair (..))
+import Prelude hiding (last)
+
+{- | True if a list is not empty.
+
+   @since 1.0.0
+-}
+pnotNull ::
+    forall (a :: S -> Type) (s :: S) list.
+    PIsListLike list a =>
+    Term
+        s
+        (list a :--> PBool)
+pnotNull =
+    phoistAcyclic $
+        plam $
+            pelimList (\_ _ -> pcon PTrue) (pcon PFalse)
+
+{- | / O(n) /. Merge two lists which are assumed to be ordered, given a custom comparator.
+    The comparator should return true if first value is less than the second one.
+
+   @since 1.0.0
+-}
+pmergeBy ::
+    forall (a :: S -> Type) (s :: S) list.
+    (PIsListLike list a) =>
+    Term
+        s
+        ( (a :--> a :--> PBool)
+            :--> list a
+            :--> list a
+            :--> list a
+        )
+pmergeBy = phoistAcyclic $ pfix #$ plam go
+  where
+    go self comp a b =
+        pif (pnull # a) b $
+            pif (pnull # b) a $
+                unTermCont $ do
+                    ah <- pletC $ phead # a
+                    at <- pletC $ ptail # a
+                    bh <- pletC $ phead # b
+                    bt <- pletC $ ptail # b
+
+                    pure $
+                        pif
+                            (comp # ah # bh)
+                            (pcons # ah #$ self # comp # at # b)
+                            (pcons # bh #$ self # comp # a # bt)
+
+{- | Split a list in half without any dividing.
+
+   @since 1.0.0
+-}
+phalve ::
+    forall (a :: S -> Type) (s :: S) list.
+    (PIsListLike list a) =>
+    Term s (list a :--> PPair (list a) (list a))
+phalve = phoistAcyclic $ plam $ \l -> go # l # l
+  where
+    go = phoistAcyclic $ pfix # plam go'
+    go' self xs ys =
+        pif
+            (pnull # ys)
+            (pcon $ PPair pnil xs)
+            ( unTermCont $ do
+                yt <- pletC $ ptail # ys
+
+                xh <- pletC $ phead # xs
+                xt <- pletC $ ptail # xs
+
+                pure $
+                    pif (pnull # yt) (pcon $ PPair (psingleton # xh) xt) $
+                        unTermCont $ do
+                            yt' <- pletC $ ptail # yt
+                            pure $
+                                pmatch (self # xt # yt') $ \(PPair first last) ->
+                                    pcon $ PPair (pcons # xh # first) last
+            )
+
+{- | / O(nlogn) /. Merge sort, bottom-up version, given a custom comparator.
+
+   Assuming the comparator returns true if first value is less than the second one,
+    the list elements will be arranged in ascending order, keeping duplicates in the order
+    they appeared in the input.
+
+   @since 1.0.0
+-}
+pmsortBy ::
+    forall (a :: S -> Type) (s :: S) list.
+    (PIsListLike list a) =>
+    Term
+        s
+        ( (a :--> a :--> PBool)
+            :--> list a
+            :--> list a
+        )
+pmsortBy = phoistAcyclic $ pfix #$ plam go
+  where
+    go self comp xs = pif (pnull # xs) pnil $
+        pif (pnull #$ ptail # xs) xs $
+            pmatch (phalve # xs) $ \(PPair fh sh) ->
+                let sfh = self # comp # fh
+                    ssh = self # comp # sh
+                 in pmergeBy # comp # sfh # ssh
+
+{- | A special case of 'pmsortBy' which requires elements have 'POrd' instance.
+
+   @since 1.0.0
+-}
+pmsort ::
+    forall (a :: S -> Type) (s :: S) list.
+    (POrd a, PIsListLike list a) =>
+    Term s (list a :--> list a)
+pmsort = phoistAcyclic $ pmsortBy # comp
+  where
+    comp = phoistAcyclic $ plam (#<)
+
+{- | / O(nlogn) /. Sort and remove dupicate elements in a list.
+
+    The first parameter is a equalator, which should return true if the two given values are equal.
+    The second parameter is a comparator, which should returns true if the first value is less than the second value.
+
+    @since 1.0.0
+-}
+pnubSortBy ::
+    forall (a :: S -> Type) (s :: S) list.
+    (PIsListLike list a) =>
+    Term
+        s
+        ( (a :--> a :--> PBool)
+            :--> (a :--> a :--> PBool)
+            :--> list a
+            :--> list a
+        )
+pnubSortBy = phoistAcyclic $
+    plam $ \eq comp l -> pif (pnull # l) l $
+        unTermCont $ do
+            sl <- pletC $ pmsortBy # comp # l
+
+            let x = phead # sl
+                xs = ptail # sl
+
+            return $ go # eq # x # xs
+  where
+    go = phoistAcyclic pfix #$ plam go'
+    go' self eq seen l =
+        pif (pnull # l) (psingleton # seen) $
+            unTermCont $ do
+                x <- pletC $ phead # l
+                xs <- pletC $ ptail # l
+
+                return $
+                    pif
+                        (eq # x # seen)
+                        (self # eq # seen # xs)
+                        (pcons # seen #$ self # eq # x # xs)
+
+{- | Special version of 'pnubSortBy', which requires elements have 'POrd' instance.
+
+   @since 1.0.0
+-}
+pnubSort ::
+    forall (a :: S -> Type) (s :: S) list.
+    (PIsListLike list a, POrd a) =>
+    Term s (list a :--> list a)
+pnubSort = phoistAcyclic $ pnubSortBy # eq # comp
+  where
+    eq = phoistAcyclic $ plam (#==)
+    comp = phoistAcyclic $ plam (#<)
+
+{- | / O(nlogn) /. Check if a list contains no duplicates.
+
+   @since 1.0.0
+-}
+pisUniqBy ::
+    forall (a :: S -> Type) (s :: S) list.
+    (PIsListLike list a) =>
+    Term
+        s
+        ( (a :--> a :--> PBool)
+            :--> (a :--> a :--> PBool)
+            :--> list a
+            :--> PBool
+        )
+pisUniqBy = phoistAcyclic $
+    plam $ \eq comp xs ->
+        let nubbed = pnubSortBy # eq # comp # xs
+         in plength # xs #== plength # nubbed
+
+{- | A special case of 'pisUniqBy' which requires elements have 'POrd' instance.
+
+   @since 1.0.0
+-}
+pisUniq ::
+    forall (a :: S -> Type) (s :: S) list.
+    (POrd a, PIsListLike list a) =>
+    Term s (list a :--> PBool)
+pisUniq = phoistAcyclic $ pisUniqBy # eq # comp
+  where
+    eq = phoistAcyclic $ plam (#==)
+    comp = phoistAcyclic $ plam (#<)
+
+{- | A special version of `pmap` which allows list elements to be thrown out.
+
+    @since 1.0.0
+-}
+pmapMaybe ::
+    forall (a :: S -> Type) (s :: S) list.
+    (PIsListLike list a) =>
+    Term
+        s
+        ( (a :--> PMaybe a)
+            :--> list a
+            :--> list a
+        )
+pmapMaybe = phoistAcyclic $
+    pfix #$ plam $ \self f l -> pif (pnull # l) pnil $
+        unTermCont $ do
+            x <- pletC $ phead # l
+            xs <- pletC $ ptail # l
+
+            pure $
+                pmatch (f # x) $ \case
+                    PJust ux -> pcons # ux #$ self # f # xs
+                    _ -> self # f # xs
+
+{- | Get the first element that matches a predicate or return Nothing.
+
+     @since 1.0.0
+-}
+pfind' ::
+    forall (a :: S -> Type) (s :: S) list.
+    PIsListLike list a =>
+    (Term s a -> Term s PBool) ->
+    Term s (list a :--> PMaybe a)
+pfind' p =
+    precList
+        (\self x xs -> pif (p x) (pcon (PJust x)) (self # xs))
+        (const $ pcon PNothing)
+
+{- | Get the first element that maps to a 'PJust' in a list.
+
+     @since 1.0.0
+-}
+pfirstJust ::
+    forall (a :: S -> Type) (b :: S -> Type) (s :: S) list.
+    PIsListLike list a =>
+    Term s ((a :--> PMaybe b) :--> list a :--> PMaybe b)
+pfirstJust =
+    phoistAcyclic $
+        plam $ \p ->
+            precList
+                ( \self x xs ->
+                    -- In the future, this should use `pmatchSum`, I believe?
+                    pmatch (p # x) $ \case
+                        PNothing -> self # xs
+                        PJust v -> pcon (PJust v)
+                )
+                (const $ pcon PNothing)
+
+{- | /O(n)/. Find the value for a given key in an associative list.
+
+     @since 1.0.0
+-}
+plookup ::
+    forall (a :: S -> Type) (b :: S -> Type) (s :: S) list.
+    (PEq a, PIsListLike list (PBuiltinPair a b)) =>
+    Term s (a :--> list (PBuiltinPair a b) :--> PMaybe b)
+plookup =
+    phoistAcyclic $
+        plam $ \k xs ->
+            pmatch (pfind' (\p -> pfstBuiltin # p #== k) # xs) $ \case
+                PNothing -> pcon PNothing
+                PJust p -> pcon (PJust (psndBuiltin # p))
+
+{- | /O(n)/. Find the value for a given key in an assoclist which uses 'PTuple's.
+
+     @since 1.0.0
+-}
+plookupTuple ::
+    (PEq a, PIsListLike list (PAsData (PTuple a b)), PIsData a, PIsData b) =>
+    Term s (a :--> list (PAsData (PTuple a b)) :--> PMaybe b)
+plookupTuple =
+    phoistAcyclic $
+        plam $ \k xs ->
+            pmatch (pfind' (\p -> (pfield @"_0" # pfromData p) #== k) # xs) $ \case
+                PNothing -> pcon PNothing
+                PJust p -> pcon (PJust (pfield @"_1" # pfromData p))
+
+{- | /O(logn)/. Search for a target in a list using binary search. The list should be sorted in in ascending order.
+
+    The first parameter is a equalator, which should return true if the two given values are equal.
+    The second parameter is a comparator, which should returns true if the first value is less than the second value.
+    The third parameter is the target which is being search for.
+
+     @since 1.0.0
+-}
+pbinarySearchBy ::
+    forall (a :: S -> Type) (b :: S -> Type) (s :: S) l.
+    (PIsListLike l a) =>
+    Term
+        s
+        ( (a :--> b :--> PBool)
+            :--> (a :--> b :--> PBool)
+            :--> b
+            :--> l a
+            :--> PMaybe a
+        )
+pbinarySearchBy = phoistAcyclic $ pfix # go
+  where
+    go = phoistAcyclic $
+        plam $ \self eq comp target inp ->
+            pif
+                (pnull # inp)
+                (pcon PNothing)
+                $ pmatch
+                    (phalve # inp)
+                    $ \(PPair fh sh) ->
+                        pif
+                            (pnull # sh)
+                            ( let x = phead # fh
+                               in pif
+                                    (eq # x # target)
+                                    (pcon $ PJust x)
+                                    (pcon PNothing)
+                            )
+                            $ plet (phead # sh) $ \mid ->
+                                pif
+                                    (eq # mid # target)
+                                    (pcon $ PJust mid)
+                                    $ pif
+                                        (comp # mid # target)
+                                        ( let next =
+                                                ptail # sh
+                                           in self # eq # comp # target # next
+                                        )
+                                        $ self # eq # comp # target # fh
+
+{- | A special version of 'pbinarySearchBy', given a term to convert list element type @a@ to another type @b@,
+     and type @b@ has 'POrd' instance.
+
+     @since 1.0.0
+-}
+pbinarySearch ::
+    forall (a :: S -> Type) (b :: S -> Type) (s :: S) l.
+    (POrd b, PIsListLike l a) =>
+    Term
+        s
+        ( (a :--> b)
+            :--> b
+            :--> l a
+            :--> PMaybe a
+        )
+pbinarySearch = phoistAcyclic $
+    plam $ \conv target list ->
+        let eq = plam $ \x y -> (conv # x) #== y
+            comp = plam $ \x y -> (conv # x) #< y
+         in pbinarySearchBy # eq # comp # target # list

--- a/src/Plutarch/Extra/Map.hs
+++ b/src/Plutarch/Extra/Map.hs
@@ -99,7 +99,7 @@ pmapFromList = pcon . PMap . foldl' go (pcon PNil)
         p <- pletC (ppairDataBuiltin # k' # v')
         pure . pcon . PCons p $ acc
 
--- | @since 1.0.0
+-- | @since 1.1.0
 pkeys ::
     forall (k :: S -> Type) (v :: S -> Type) (keys :: KeyGuarantees) (s :: S).
     Term s (PMap keys k v :--> PBuiltinList (PAsData k))
@@ -110,7 +110,7 @@ pkeys = phoistAcyclic $
 
 {- | / O(n) /. Update the value at a given key in a `PMap`, have the same functionalities as 'Data.Map.update'.
 
-     @since 1.0.0
+     @since 1.1.0
 -}
 pupdate ::
     forall (k :: S -> Type) (v :: S -> Type) (keys :: KeyGuarantees) (s :: S).
@@ -138,7 +138,7 @@ pupdate = phoistAcyclic $
 
 {- | / O(n) /. Map a function over all values in a 'PMap'.
 
-     @since 1.0.0
+     @since 1.1.0
 -}
 pmap ::
     forall (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (keys :: KeyGuarantees) (s :: S).

--- a/src/Plutarch/Extra/Map.hs
+++ b/src/Plutarch/Extra/Map.hs
@@ -1,24 +1,37 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ViewPatterns #-}
+
 module Plutarch.Extra.Map (
     plookup,
     plookup',
     pmapFromList,
     pkeys,
+    pupdate,
+    pmap,
+    punionWith,
+    pkeysEqual,
+
+    -- * PlutusTx Utilities.
+    update,
 ) where
 
 import Data.Foldable (foldl')
 import Data.Kind (Type)
 import Plutarch (
+    PMatch (pmatch),
     S,
     Term,
     pcon,
     phoistAcyclic,
     plam,
+    pto,
     unTermCont,
     (#),
+    (#$),
     type (:-->),
  )
 import Plutarch.Api.V1.AssocMap (KeyGuarantees, PMap (PMap))
-import Plutarch.Bool (PBool, PEq ((#==)))
+import Plutarch.Bool (PBool (PFalse), PEq ((#==)), POrd ((#<)), pif, pnot)
 import Plutarch.Builtin (
     PAsData,
     PBuiltinList (PCons, PNil),
@@ -32,10 +45,14 @@ import Plutarch.Builtin (
     psndBuiltin,
  )
 import Plutarch.Extra.Functor (pfmap)
+import Plutarch.Extra.List (pmapMaybe, pmsortBy)
+import qualified Plutarch.Extra.List
 import Plutarch.Extra.TermCont (pletC, pmatchC)
-import Plutarch.List (pfind)
+import Plutarch.List (pany, pconcat, pfilter, pfind, plength, plistEquals)
+import qualified Plutarch.List
 import Plutarch.Maybe (PMaybe (PJust, PNothing))
 import Plutarch.Trace (ptraceError)
+import qualified PlutusTx.AssocMap as AssocMap
 
 -- | @since 1.0.0
 plookup ::
@@ -96,3 +113,141 @@ pkeys = phoistAcyclic $
     plam $ \m -> unTermCont $ do
         PMap kvs <- pmatchC m
         pure $ pfmap # pfstBuiltin # kvs
+
+{- | / O(n) /. Update the value at a given key in a `PMap`, have the same functionalities as 'Data.Map.update'.
+
+     @since 1.0.0
+-}
+pupdate ::
+    forall (k :: S -> Type) (v :: S -> Type) (keys :: KeyGuarantees) (s :: S).
+    (PIsData k, PIsData v) =>
+    Term s ((v :--> PMaybe v) :--> k :--> PMap keys k v :--> PMap keys k v)
+pupdate = phoistAcyclic $
+    plam $ \f (pdata -> tk) (pto -> (ps :: Term _ (PBuiltinList _))) ->
+        pcon $
+            PMap $
+                pmapMaybe
+                    # plam
+                        ( \kv ->
+                            let k = pfstBuiltin # kv
+                                v = pfromData $ psndBuiltin # kv
+                             in pif
+                                    (k #== tk)
+                                    ( pmatch (f # v) $
+                                        \case
+                                            PJust uv -> pcon $ PJust $ ppairDataBuiltin # k # pdata uv
+                                            _ -> pcon PNothing
+                                    )
+                                    (pcon $ PJust kv)
+                        )
+                    # ps
+
+{- | / O(n) /. Map a function over all values in a 'PMap'.
+
+     @since 1.0.0
+-}
+pmap ::
+    forall (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (keys :: KeyGuarantees) (s :: S).
+    (PIsData k, PIsData a, PIsData b) =>
+    Term s ((a :--> b) :--> PMap keys k a :--> PMap keys k b)
+pmap = phoistAcyclic $
+    plam $ \f (pto -> (ps :: Term _ (PBuiltinList _))) ->
+        pcon $
+            PMap $
+                Plutarch.List.pmap
+                    # plam
+                        ( \kv ->
+                            let k = pfstBuiltin # kv
+                                v = psndBuiltin # kv
+
+                                nv = pdata $ f # pfromData v
+                             in ppairDataBuiltin # k # nv
+                        )
+                    # ps
+
+{- | Union two maps using a merge function on collisions.
+
+    TODO(Emily): this function is kinda suspect. I feel like a lot of optimizations could be done here
+    TODO: optimize this
+
+    @since 1.0.0
+-}
+punionWith ::
+    forall (k :: S -> Type) (v :: S -> Type) (keys :: KeyGuarantees) (s :: S).
+    PIsData v =>
+    Term
+        s
+        ( (v :--> v :--> v)
+            :--> PMap keys k v
+            :--> PMap keys k v
+            :--> PMap keys k v
+        )
+punionWith = phoistAcyclic $
+    plam $ \f xs' ys' -> unTermCont $ do
+        PMap xs <- pmatchC xs'
+        PMap ys <- pmatchC ys'
+        let ls =
+                Plutarch.List.pmap
+                    # plam
+                        ( \p -> unTermCont $ do
+                            pf <- pletC $ pfstBuiltin # p
+                            pure $
+                                pmatch (Plutarch.Extra.List.plookup # pf # ys) $ \case
+                                    PJust v ->
+                                        -- Data conversions here are silly, aren't they?
+                                        ppairDataBuiltin # pf # pdata (f # pfromData (psndBuiltin # p) # pfromData v)
+                                    PNothing -> p
+                        )
+                    # xs
+            rs =
+                pfilter
+                    # plam
+                        ( \p ->
+                            pnot #$ pany # plam (\p' -> pfstBuiltin # p' #== pfstBuiltin # p) # xs
+                        )
+                    # ys
+        pure $ pcon (PMap $ pconcat # ls # rs)
+
+{- | True if both maps have exactly the same keys.
+     Using @'#=='@ is not sufficient, because keys returned are not ordered.
+
+    @since 1.0.0
+-}
+pkeysEqual ::
+    forall (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (keys :: KeyGuarantees) (s :: S).
+    (POrd k, PIsData k) =>
+    Term s (PMap keys k a :--> PMap keys k b :--> PBool)
+pkeysEqual = phoistAcyclic $
+    plam $ \p q -> unTermCont $ do
+        pks <- pletC $ pkeys # p
+        qks <- pletC $ pkeys # q
+
+        pure $
+            pif
+                (plength # pks #== plength # qks)
+                ( unTermCont $ do
+                    let comp = phoistAcyclic $ plam $ \(pfromData -> x) (pfromData -> y) -> x #< y
+                        spks = pmsortBy # comp # pks
+                        sqks = pmsortBy # comp # qks
+
+                    pure $ plistEquals # spks # sqks
+                )
+                (pcon PFalse)
+
+--------------------------------------------------------------------------------
+-- Haskell level utilities.
+
+{- | / O(n) /. The expression @'updateMap' f k v@ will update the value @x@ at key @k@.
+    If @f x@ is Nothing, the key-value pair will be deleted from the map, otherwise the
+     value will be updated.
+
+     @since 1.0.0
+-}
+update :: Eq k => (v -> Maybe v) -> k -> AssocMap.Map k v -> AssocMap.Map k v
+update f k =
+    AssocMap.mapMaybeWithKey
+        ( \k' v ->
+            if k' == k
+                then f v
+                else Just v
+        )

--- a/src/Plutarch/Extra/Map.hs
+++ b/src/Plutarch/Extra/Map.hs
@@ -99,7 +99,10 @@ pmapFromList = pcon . PMap . foldl' go (pcon PNil)
         p <- pletC (ppairDataBuiltin # k' # v')
         pure . pcon . PCons p $ acc
 
--- | @since 1.1.0
+{- | Get the keys of a given map, the order of the keys is preserved.
+
+      @since 1.1.0
+-}
 pkeys ::
     forall (k :: S -> Type) (v :: S -> Type) (keys :: KeyGuarantees) (s :: S).
     Term s (PMap keys k v :--> PBuiltinList (PAsData k))
@@ -161,14 +164,14 @@ pmap = phoistAcyclic $
 
 {- | Get the key of a key-value pair.
 
-     @since 1.0.0
+     @since 1.1.0
 -}
 pkvPairKey :: (PIsData k) => Term s (PBuiltinPair (PAsData k) (PAsData v) :--> k)
 pkvPairKey = phoistAcyclic $ plam $ \(pfromData . (pfstBuiltin #) -> key) -> key
 
 {- | Compare two key-value pairs by their keys, return true if the first key is less than the second one.
 
-      @since 1.0.0
+      @since 1.1.0
 -}
 pkvPairLt ::
     (PIsData k, POrd k) =>

--- a/src/Plutarch/Extra/Map/Sorted.hs
+++ b/src/Plutarch/Extra/Map/Sorted.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Plutarch.Extra.Map.Sorted (pkeysEqual, punionWith) where
+
+import Data.Kind (Type)
+import Plutarch (
+    S,
+    Term,
+    pcon,
+    pfix,
+    phoistAcyclic,
+    plam,
+    pto,
+    unTermCont,
+    (#),
+    (#$),
+    type (:-->),
+ )
+import Plutarch.Api.V1.AssocMap (KeyGuarantees (..), PMap (PMap))
+import Plutarch.Bool (PBool, PEq ((#==)), POrd ((#<)), pif)
+import Plutarch.Builtin (
+    PAsData,
+    PBuiltinList,
+    PBuiltinPair,
+    PIsData,
+    pdata,
+    pfromData,
+    pfstBuiltin,
+    ppairDataBuiltin,
+    psndBuiltin,
+ )
+import Plutarch.Extra.Map (pkeys)
+import Plutarch.Extra.TermCont (pletC)
+import Plutarch.List (PListLike (..), plistEquals)
+
+{- | / O(n) /. True if both maps have exactly the same keys.
+
+    @since 1.0.0
+-}
+pkeysEqual ::
+    forall (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
+    Term s (PMap 'Sorted k a :--> PMap 'Sorted k b :--> PBool)
+pkeysEqual =
+    phoistAcyclic $
+        plam $
+            \((pkeys #) -> keysA)
+             ((pkeys #) -> keysB) ->
+                    plistEquals # keysA # keysB
+
+{- | / O(n) /. Union two maps using a merge function on collisions.
+
+    @since 1.0.0
+-}
+punionWith ::
+    forall (k :: S -> Type) (v :: S -> Type) (s :: S).
+    (PIsData k, POrd k, PIsData v) =>
+    Term
+        s
+        ( (v :--> v :--> v)
+            :--> PMap 'Sorted k v
+            :--> PMap 'Sorted k v
+            :--> PMap 'Sorted k v
+        )
+punionWith =
+    phoistAcyclic $
+        plam $
+            \merger
+             (pto -> a :: Term _ (PBuiltinList _))
+             (pto -> b :: Term _ (PBuiltinList _)) ->
+                    pcon $ PMap $ merge # (mkMerger # merger) # a # b
+  where
+    mkMerger ::
+        Term
+            _
+            ( (v :--> v :--> v)
+                :--> PBuiltinPair (PAsData k) (PAsData v)
+                :--> PBuiltinPair (PAsData k) (PAsData v)
+                :--> PBuiltinPair (PAsData k) (PAsData v)
+            )
+    mkMerger = phoistAcyclic $
+        plam $ \f a b ->
+            let k = pfstBuiltin # a
+                va = pfromData $ psndBuiltin # a
+                vb = pfromData $ psndBuiltin # b
+                v = pdata $ f # va # vb
+             in ppairDataBuiltin # k # v
+
+    merge ::
+        Term
+            _
+            ( ( PBuiltinPair (PAsData k) (PAsData v)
+                    :--> PBuiltinPair (PAsData k) (PAsData v)
+                    :--> PBuiltinPair (PAsData k) (PAsData v)
+              )
+                :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+                :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+                :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+            )
+    merge = phoistAcyclic $
+        pfix #$ plam $ \self' merger a b ->
+            pif (pnull # a) b $
+                pif (pnull # b) a $
+                    unTermCont $ do
+                        self <- pletC $ self' # merger
+
+                        ah <- pletC $ phead # a
+                        at <- pletC $ ptail # a
+                        bh <- pletC $ phead # b
+                        bt <- pletC $ ptail # b
+
+                        ahk <- pletC $ pfromData $ pfstBuiltin # ah
+                        bhk <- pletC $ pfromData $ pfstBuiltin # bh
+
+                        pure $
+                            pif
+                                (ahk #== bhk)
+                                ( pcons # (merger # ah # bh)
+                                    # (self # at # bt)
+                                )
+                                $ pif
+                                    (ahk #< bhk)
+                                    (pcons # ah #$ self # at # b)
+                                    (pcons # bh #$ self # a # bt)

--- a/src/Plutarch/Extra/Map/Sorted.hs
+++ b/src/Plutarch/Extra/Map/Sorted.hs
@@ -36,7 +36,7 @@ import Plutarch.List (PListLike (..), plistEquals)
 
 {- | / O(n) /. True if both maps have exactly the same keys.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pkeysEqual ::
     forall (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
@@ -50,7 +50,7 @@ pkeysEqual =
 
 {- | / O(n) /. Union two maps using a merge function on collisions.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 punionWith ::
     forall (k :: S -> Type) (v :: S -> Type) (s :: S).

--- a/src/Plutarch/Extra/Map/Unsorted.hs
+++ b/src/Plutarch/Extra/Map/Unsorted.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Plutarch.Extra.Map.Unsorted (
+    psort,
+    pkeysEqual,
+    punionWith,
+) where
+
+import Data.Kind (Type)
+import Plutarch (
+    S,
+    Term,
+    pcon,
+    phoistAcyclic,
+    plam,
+    pto,
+    unTermCont,
+    (#),
+    type (:-->),
+ )
+import Plutarch.Api.V1.AssocMap (KeyGuarantees (..), PMap (PMap))
+import Plutarch.Bool (PBool (PFalse), PEq ((#==)), POrd ((#<)), pif)
+import Plutarch.Builtin (
+    PBuiltinList,
+    PIsData,
+    pfromData,
+ )
+import Plutarch.Extra.List (pmsortBy)
+import Plutarch.Extra.Map (pkeys, pkvPairLt)
+import qualified Plutarch.Extra.Map.Sorted as SortedMap
+import Plutarch.Extra.TermCont (pletC)
+import Plutarch.List (plength, plistEquals)
+
+{- | / O(nlogn) /. Sort a `PMap` by the keys of each key-value pairs, in an ascending order.
+
+    @since 1.0.0
+-}
+psort ::
+    forall (k :: S -> Type) (v :: S -> Type) (s :: S).
+    (PIsData k, POrd k) =>
+    Term s (PMap 'Unsorted k v :--> PMap 'Sorted k v)
+psort = phoistAcyclic $
+    plam $ \(pto -> l :: (Term _ (PBuiltinList _))) ->
+        pcon $ PMap $ pmsortBy # pkvPairLt # l
+
+{- | / O(nlogn) /. True if both maps have exactly the same keys.
+     Using @'#=='@ is not sufficient, because keys returned are not ordered.
+
+    @since 1.0.0
+-}
+pkeysEqual ::
+    forall (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
+    (POrd k, PIsData k) =>
+    Term s (PMap 'Unsorted k a :--> PMap 'Unsorted k b :--> PBool)
+pkeysEqual = phoistAcyclic $
+    plam $ \p q -> unTermCont $ do
+        pks <- pletC $ pkeys # p
+        qks <- pletC $ pkeys # q
+
+        pure $
+            pif
+                (plength # pks #== plength # qks)
+                ( unTermCont $ do
+                    let comp = phoistAcyclic $ plam $ \(pfromData -> x) (pfromData -> y) -> x #< y
+                        spks = pmsortBy # comp # pks
+                        sqks = pmsortBy # comp # qks
+
+                    pure $ plistEquals # spks # sqks
+                )
+                (pcon PFalse)
+
+{- | / O(nlogn) /. Union two maps using a merge function on collisions.
+
+    @since 1.0.0
+-}
+punionWith ::
+    forall (k :: S -> Type) (v :: S -> Type) (s :: S).
+    (PIsData k, POrd k, PIsData v) =>
+    Term
+        s
+        ( (v :--> v :--> v)
+            :--> PMap 'Unsorted k v
+            :--> PMap 'Unsorted k v
+            :--> PMap 'Sorted k v
+        )
+punionWith = phoistAcyclic $
+    plam $ \f a b ->
+        let sa = psort # a
+            sb = psort # b
+         in SortedMap.punionWith # f # sa # sb

--- a/src/Plutarch/Extra/Map/Unsorted.hs
+++ b/src/Plutarch/Extra/Map/Unsorted.hs
@@ -34,7 +34,7 @@ import Plutarch.List (plength, plistEquals)
 
 {- | / O(nlogn) /. Sort a `PMap` by the keys of each key-value pairs, in an ascending order.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 psort ::
     forall (k :: S -> Type) (v :: S -> Type) (s :: S).
@@ -47,7 +47,7 @@ psort = phoistAcyclic $
 {- | / O(nlogn) /. True if both maps have exactly the same keys.
      Using @'#=='@ is not sufficient, because keys returned are not ordered.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pkeysEqual ::
     forall (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
@@ -72,7 +72,7 @@ pkeysEqual = phoistAcyclic $
 
 {- | / O(nlogn) /. Union two maps using a merge function on collisions.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 punionWith ::
     forall (k :: S -> Type) (v :: S -> Type) (s :: S).

--- a/src/Plutarch/Extra/Maybe.hs
+++ b/src/Plutarch/Extra/Maybe.hs
@@ -1,59 +1,156 @@
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Plutarch.Extra.Maybe (
-    pfromMaybe,
-    pfromMaybeData,
+    -- * Utility functions for working with 'PMaybe'
+    pfromJust,
     ptraceIfNothing,
+    pisJust,
+    pmaybe,
+
+    -- * Utility functions for working with 'PMaybeData'
+    pfromDJust,
+    pisDJust,
+
+    -- * Conversion between 'PMaybe' and 'PMaybeData'
+    pmaybeToMaybeData,
+
+    -- * TermCont-based combinators
+    pexpectJustC,
 ) where
 
 import Data.Kind (Type)
 import Plutarch (
+    PCon (pcon),
     S,
     Term,
     phoistAcyclic,
     plam,
     pmatch,
-    unTermCont,
     (#),
     type (:-->),
  )
 import Plutarch.Api.V1.Maybe (PMaybeData (PDJust, PDNothing))
-import Plutarch.Builtin (PIsData, pfromData)
-import Plutarch.DataRepr (pfield)
-import Plutarch.Extra.TermCont (pmatchC)
+import Plutarch.Bool (PBool)
+import Plutarch.Builtin (PIsData, pdata, pfromData)
+import Plutarch.DataRepr (pdcons, pdnil, pfield)
+import Plutarch.Lift (pconstant)
 import Plutarch.Maybe (PMaybe (PJust, PNothing))
 import Plutarch.String (PString)
+import Plutarch.TermCont (TermCont, tcont)
 import Plutarch.Trace (ptraceError)
 
--- | @since 1.0.0
-pfromMaybe ::
+--------------------------------------------------------------------------------
+-- Utility functions for working with 'PMaybe'.
+
+{- | Extracts the element out of a 'PJust' and throws an error if its argument is 'PNothing'.
+
+    @since 1.0.0
+-}
+pfromJust ::
     forall (a :: S -> Type) (s :: S).
     Term s (PMaybe a :--> a)
-pfromMaybe = phoistAcyclic $
-    plam $ \t -> unTermCont $ do
-        t' <- pmatchC t
-        pure $ case t' of
-            PNothing -> ptraceError "pfromMaybe: found PNothing"
-            PJust x -> x
+pfromJust = phoistAcyclic $
+    plam $ \t -> pmatch t $ \case
+        PNothing -> ptraceError "pfromJust: found PNothing"
+        PJust x -> x
 
--- | @since 1.0.0
-pfromMaybeData ::
-    forall (a :: S -> Type) (s :: S).
-    (PIsData a) =>
-    Term s (PMaybeData a :--> a)
-pfromMaybeData = phoistAcyclic $
-    plam $ \t -> unTermCont $ do
-        t' <- pmatchC t
-        case t' of
-            PDNothing _ -> pure . ptraceError $ "pfromMaybeData: found PDNothing"
-            PDJust x -> pure (pfromData $ pfield @"_0" # x)
+{- | Extracts the element out of a 'PJust' and throws a custom error if it's given a 'PNothing'.
 
--- | @since 1.0.0
+    @since 1.0.0
+-}
 ptraceIfNothing ::
     forall (a :: S -> Type) (s :: S).
+    -- | The custom error message.
     Term s PString ->
     Term s (PMaybe a) ->
     Term s a
 ptraceIfNothing err t = pmatch t $ \case
     PNothing -> ptraceError err
     PJust x -> x
+
+{- | Yields true if the given 'PMaybe' value is of form @'PJust' _@.
+
+    @since 1.0.0
+-}
+pisJust ::
+    forall (a :: S -> Type) (s :: S).
+    Term s (PMaybe a :--> PBool)
+pisJust = phoistAcyclic $
+    plam $ \v' ->
+        pmatch v' $ \case
+            PJust _ -> pconstant True
+            _ -> pconstant False
+
+{- | Extract a 'PMaybe' by providing a default value in case of 'PJust'.
+
+    @since 1.0.0
+-}
+pmaybe ::
+    forall (a :: S -> Type) (s :: S).
+    Term s (a :--> PMaybe a :--> a)
+pmaybe = phoistAcyclic $
+    plam $ \e a -> pmatch a $ \case
+        PJust a' -> a'
+        PNothing -> e
+
+--------------------------------------------------------------------------------
+-- Utility functions for working with 'PMaybeData'.
+
+{- | Extracts the element out of a 'PDJust' and throws an error if its argument is 'PDNothing'.
+
+    @since 1.0.0
+-}
+pfromDJust ::
+    forall (a :: S -> Type) (s :: S).
+    (PIsData a) =>
+    Term s (PMaybeData a :--> a)
+pfromDJust = phoistAcyclic $
+    plam $ \t -> pmatch t $ \case
+        PDNothing _ -> ptraceError "pfromDJust: found PDNothing"
+        PDJust x -> pfromData $ pfield @"_0" # x
+
+{- | Yield True if a given 'PMaybeData' is of form @'PDJust' _@.
+
+    @since 1.0.0
+-}
+pisDJust ::
+    forall (a :: S -> Type) (s :: S).
+    Term s (PMaybeData a :--> PBool)
+pisDJust = phoistAcyclic $
+    plam $ \x -> pmatch x $ \case
+        PDJust _ -> pconstant True
+        _ -> pconstant False
+
+--------------------------------------------------------------------------------
+-- Conversion between 'PMaybe' and 'PMaybeData'.
+
+{- | Copnsturct a 'PMaybeData' given a 'PMaybe'. Could be useful if you want to "lift" from 'PMaybe' to 'Maybe'.
+
+    @since 1.0.0
+-}
+pmaybeToMaybeData ::
+    forall (a :: S -> Type) (s :: S).
+    (PIsData a) =>
+    Term s (PMaybe a :--> PMaybeData a)
+pmaybeToMaybeData = phoistAcyclic $
+    plam $ \t -> pmatch t $ \case
+        PNothing -> pcon $ PDNothing pdnil
+        PJust x -> pcon $ PDJust $ pdcons @"_0" # pdata x # pdnil
+
+--------------------------------------------------------------------------------
+-- TermCont-based combinators.
+
+{- | Escape with a particular value on expecting 'Just'. For use in monadic context.
+
+    @since 1.0.0
+-}
+pexpectJustC ::
+    forall (a :: S -> Type) (r :: S -> Type) (s :: S).
+    Term s r ->
+    Term s (PMaybe a) ->
+    TermCont @r s (Term s a)
+pexpectJustC escape ma = tcont $ \f ->
+    pmatch ma $ \case
+        PJust v -> f v
+        PNothing -> escape

--- a/src/Plutarch/Extra/Maybe.hs
+++ b/src/Plutarch/Extra/Maybe.hs
@@ -45,7 +45,7 @@ import Plutarch.Trace (ptraceError)
 
 {- | Extracts the element out of a 'PJust' and throws an error if its argument is 'PNothing'.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pfromJust ::
     forall (a :: S -> Type) (s :: S).
@@ -71,7 +71,7 @@ ptraceIfNothing err t = pmatch t $ \case
 
 {- | Yields true if the given 'PMaybe' value is of form @'PJust' _@.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pisJust ::
     forall (a :: S -> Type) (s :: S).
@@ -84,7 +84,7 @@ pisJust = phoistAcyclic $
 
 {- | Extract a 'PMaybe' by providing a default value in case of 'PJust'.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pmaybe ::
     forall (a :: S -> Type) (s :: S).
@@ -99,7 +99,7 @@ pmaybe = phoistAcyclic $
 
 {- | Extracts the element out of a 'PDJust' and throws an error if its argument is 'PDNothing'.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pfromDJust ::
     forall (a :: S -> Type) (s :: S).
@@ -112,7 +112,7 @@ pfromDJust = phoistAcyclic $
 
 {- | Yield True if a given 'PMaybeData' is of form @'PDJust' _@.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pisDJust ::
     forall (a :: S -> Type) (s :: S).
@@ -127,7 +127,7 @@ pisDJust = phoistAcyclic $
 
 {- | Copnsturct a 'PMaybeData' given a 'PMaybe'. Could be useful if you want to "lift" from 'PMaybe' to 'Maybe'.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pmaybeToMaybeData ::
     forall (a :: S -> Type) (s :: S).
@@ -143,7 +143,7 @@ pmaybeToMaybeData = phoistAcyclic $
 
 {- | Escape with a particular value on expecting 'Just'. For use in monadic context.
 
-    @since 1.0.0
+    @since 1.1.0
 -}
 pexpectJustC ::
     forall (a :: S -> Type) (r :: S -> Type) (s :: S).

--- a/src/Plutarch/Extra/TermCont.hs
+++ b/src/Plutarch/Extra/TermCont.hs
@@ -1,10 +1,4 @@
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE TypeApplications #-}
-
-module Plutarch.Extra.TermCont (
-    passertC,
-    module Extra,
-) where
+module Plutarch.Extra.TermCont (module Extra) where
 
 import "plutarch-extra" Plutarch.Extra.TermCont as Extra (
     pguardC,
@@ -15,24 +9,3 @@ import "plutarch-extra" Plutarch.Extra.TermCont as Extra (
     ptraceC,
     ptryFromC,
  )
-
-import Plutarch (
-    S,
-    Term,
- )
-import Plutarch.Bool (PBool, pif)
-import Plutarch.String (PString)
-import Plutarch.TermCont (TermCont, tcont)
-import Plutarch.Trace (ptraceError)
-
-{- | Assert a particular 'PBool', trace if false.
-
-    @since 1.0.0
--}
-passertC ::
-    forall r (s :: S).
-    Term s PString ->
-    Term s PBool ->
-    TermCont @r s ()
-passertC errorMessage check = tcont $ \k ->
-    pif check (k ()) (ptraceError errorMessage)

--- a/src/Plutarch/Extra/TermCont.hs
+++ b/src/Plutarch/Extra/TermCont.hs
@@ -1,0 +1,11 @@
+module Plutarch.Extra.TermCont (module Extra) where
+
+import "plutarch-extra" Plutarch.Extra.TermCont as Extra (
+    pguardC,
+    pguardC',
+    pletC,
+    pletFieldsC,
+    pmatchC,
+    ptraceC,
+    ptryFromC,
+ )

--- a/src/Plutarch/Extra/TermCont.hs
+++ b/src/Plutarch/Extra/TermCont.hs
@@ -1,4 +1,10 @@
-module Plutarch.Extra.TermCont (module Extra) where
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Plutarch.Extra.TermCont (
+    passertC,
+    module Extra,
+) where
 
 import "plutarch-extra" Plutarch.Extra.TermCont as Extra (
     pguardC,
@@ -9,3 +15,24 @@ import "plutarch-extra" Plutarch.Extra.TermCont as Extra (
     ptraceC,
     ptryFromC,
  )
+
+import Plutarch (
+    S,
+    Term,
+ )
+import Plutarch.Bool (PBool, pif)
+import Plutarch.String (PString)
+import Plutarch.TermCont (TermCont, tcont)
+import Plutarch.Trace (ptraceError)
+
+{- | Assert a particular 'PBool', trace if false.
+
+    @since 1.0.0
+-}
+passertC ::
+    forall r (s :: S).
+    Term s PString ->
+    Term s PBool ->
+    TermCont @r s ()
+passertC errorMessage check = tcont $ \k ->
+    pif check (k ()) (ptraceError errorMessage)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,10 +3,15 @@ import Test.Tasty (defaultMain, testGroup)
 
 --------------------------------------------------------------------------------
 
+import qualified Spec.Extra.List as List
+
 --------------------------------------------------------------------------------
 
 main :: IO ()
 main = do
     setLocaleEncoding utf8
     defaultMain $
-        testGroup "test suiite" []
+        testGroup
+            "test suite"
+            [ testGroup "list utilities" List.tests
+            ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,6 +4,7 @@ import Test.Tasty (defaultMain, testGroup)
 --------------------------------------------------------------------------------
 
 import qualified Spec.Extra.List as List
+import qualified Spec.Extra.Map as Map
 
 --------------------------------------------------------------------------------
 
@@ -14,4 +15,5 @@ main = do
         testGroup
             "test suite"
             [ testGroup "list utilities" List.tests
+            , testGroup "map utilities" Map.tests
             ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,6 +3,7 @@ import Test.Tasty (defaultMain, testGroup)
 
 --------------------------------------------------------------------------------
 
+import qualified Spec.Api.V1.Value as Value
 import qualified Spec.Extra.List as List
 import qualified Spec.Extra.Map as Map
 
@@ -16,4 +17,5 @@ main = do
             "test suite"
             [ testGroup "list utilities" List.tests
             , testGroup "map utilities" Map.tests
+            , testGroup "value utilities" Value.tests
             ]

--- a/test/Spec/Api/V1/Value.hs
+++ b/test/Spec/Api/V1/Value.hs
@@ -1,0 +1,9 @@
+module Spec.Api.V1.Value (tests) where
+
+import qualified Spec.Api.V1.Value.Unsorted as Unsorted
+import Test.Tasty (TestTree, testGroup)
+
+tests :: [TestTree]
+tests =
+    [ testGroup "unsorted values" Unsorted.tests
+    ]

--- a/test/Spec/Api/V1/Value/Unsorted.hs
+++ b/test/Spec/Api/V1/Value/Unsorted.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+
+module Spec.Api.V1.Value.Unsorted (tests) where
+
+--------------------------------------------------------------------------------
+
+import Spec.Utils (
+    genValue,
+    sortValue,
+ )
+import Test.QuickCheck (
+    Property,
+    shrinkNothing,
+ )
+import Test.Tasty (TestTree)
+import Test.Tasty.Plutarch.Property (peqPropertyNative')
+import Test.Tasty.QuickCheck (
+    testProperty,
+ )
+
+--------------------------------------------------------------------------------
+
+import Plutarch (phoistAcyclic, plam, (#))
+import Plutarch.Unsafe (punsafeCoerce)
+import qualified PlutusLedgerApi.V1.Value as Value
+
+--------------------------------------------------------------------------------
+
+import Plutarch.Api.V1.Value.Unsorted (psort)
+
+--------------------------------------------------------------------------------
+
+tests :: [TestTree]
+tests =
+    [ testProperty "'psort' sorts unsorted values as expcted" prop_psortCorrect
+    ]
+
+-- | The property of 'psort' to make an unsorted value sorted.
+prop_psortCorrect :: Property
+prop_psortCorrect =
+    peqPropertyNative'
+        expected
+        genValue
+        shrinkNothing
+        definition
+  where
+    expected = Value.getValue . sortValue
+    definition = phoistAcyclic $
+        plam $ \m ->
+            punsafeCoerce $ psort # m

--- a/test/Spec/Extra/List.hs
+++ b/test/Spec/Extra/List.hs
@@ -6,7 +6,7 @@ module Spec.Extra.List (tests) where
 
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (
-  testProperty,
+    testProperty,
  )
 
 --------------------------------------------------------------------------------
@@ -33,11 +33,11 @@ import Plutarch.Extra.List (pisUniq, pmergeBy, pmsort, pnubSort)
 
 tests :: [TestTree]
 tests =
-  [ testProperty "'pmsort' sorts a list properly" prop_msortCorrect
-  , testProperty "'pmerge' merges two sorted lists into one sorted list" prop_mergeCorrect
-  , testProperty "'pnubSort' sorts a list and remove duplicate elements" prop_nubSortProperly
-  , testProperty "'pisUniq' can tell whether all elements in a list are unique" prop_uniqueList
-  ]
+    [ testProperty "'pmsort' sorts a list properly" prop_msortCorrect
+    , testProperty "'pmerge' merges two sorted lists into one sorted list" prop_mergeCorrect
+    , testProperty "'pnubSort' sorts a list and remove duplicate elements" prop_nubSortProperly
+    , testProperty "'pisUniq' can tell whether all elements in a list are unique" prop_uniqueList
+    ]
 
 --------------------------------------------------------------------------------
 -- Prperties.
@@ -45,76 +45,76 @@ tests =
 -- | Yield true if 'pmsort' sorts a given list correctly.
 prop_msortCorrect :: [Integer] -> Bool
 prop_msortCorrect l = sorted == expected
- where
-  -- Expected sorted list, using 'Data.List.sort'.
-  expected :: [Integer]
-  expected = sort l
+  where
+    -- Expected sorted list, using 'Data.List.sort'.
+    expected :: [Integer]
+    expected = sort l
 
-  --
+    --
 
-  psorted :: Term s (PBuiltinList PInteger)
-  psorted = pmsort # pconstant l
+    psorted :: Term s (PBuiltinList PInteger)
+    psorted = pmsort # pconstant l
 
-  sorted :: [Integer]
-  sorted = plift psorted
+    sorted :: [Integer]
+    sorted = plift psorted
 
 -- | Yield true if 'pmerge' merges two list into a ordered list correctly.
 prop_mergeCorrect :: [Integer] -> [Integer] -> Bool
 prop_mergeCorrect a b = merged == expected
- where
-  -- Sorted list a and b
-  sa = sort a
-  sb = sort b
+  where
+    -- Sorted list a and b
+    sa = sort a
+    sb = sort b
 
-  -- Merge two lists which are assumed to be ordered.
-  merge :: [Integer] -> [Integer] -> [Integer]
-  merge xs [] = xs
-  merge [] ys = ys
-  merge sx@(x : xs) sy@(y : ys)
-    | x <= y = x : merge xs sy
-    | otherwise = y : merge sx ys
+    -- Merge two lists which are assumed to be ordered.
+    merge :: [Integer] -> [Integer] -> [Integer]
+    merge xs [] = xs
+    merge [] ys = ys
+    merge sx@(x : xs) sy@(y : ys)
+        | x <= y = x : merge xs sy
+        | otherwise = y : merge sx ys
 
-  expected :: [Integer]
-  expected = merge sa sb
+    expected :: [Integer]
+    expected = merge sa sb
 
-  --
+    --
 
-  pmerged :: Term _ (PBuiltinList PInteger)
-  pmerged = pmergeBy # plam (#<) # pconstant sa # pconstant sb
+    pmerged :: Term _ (PBuiltinList PInteger)
+    pmerged = pmergeBy # plam (#<) # pconstant sa # pconstant sb
 
-  merged :: [Integer]
-  merged = plift pmerged
+    merged :: [Integer]
+    merged = plift pmerged
 
 {- | Yield true if 'pnubSort' sorts and removes
    duplicate elements from a given list.
 -}
 prop_nubSortProperly :: [Integer] -> Bool
 prop_nubSortProperly l = nubbed == expected
- where
-  -- Sort and list and then nub it.
-  expected :: [Integer]
-  expected = nub $ sort l
+  where
+    -- Sort and list and then nub it.
+    expected :: [Integer]
+    expected = nub $ sort l
 
-  --
+    --
 
-  pnubbed :: Term _ (PBuiltinList PInteger)
-  pnubbed = pnubSort # pconstant l
+    pnubbed :: Term _ (PBuiltinList PInteger)
+    pnubbed = pnubSort # pconstant l
 
-  nubbed :: [Integer]
-  nubbed = plift pnubbed
+    nubbed :: [Integer]
+    nubbed = plift pnubbed
 
 {- | Yield true if 'isUnique' can correctly determine
    whether a given list only contains unique elements or not.
 -}
 prop_uniqueList :: [Integer] -> Bool
 prop_uniqueList l = isUnique == expected
- where
-  -- Convert input list to a set.
-  -- If the set's size equals to list's size,
-  --   the list only contains unique elements.
-  expected :: Bool
-  expected = S.size (S.fromList l) == length l
+  where
+    -- Convert input list to a set.
+    -- If the set's size equals to list's size,
+    --   the list only contains unique elements.
+    expected :: Bool
+    expected = S.size (S.fromList l) == length l
 
-  --
+    --
 
-  isUnique = plift $ pisUniq # pconstant l
+    isUnique = plift $ pisUniq # pconstant l

--- a/test/Spec/Extra/List.hs
+++ b/test/Spec/Extra/List.hs
@@ -1,0 +1,226 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Spec.Extra.List (tests) where
+
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (
+    Arbitrary (arbitrary),
+    Property,
+    Testable (property),
+    elements,
+    forAll,
+    suchThat,
+    testProperty,
+    (.&&.),
+ )
+
+--------------------------------------------------------------------------------
+
+import Data.List (nub, sort, sortBy)
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Prelude hiding (last)
+
+--------------------------------------------------------------------------------
+
+import Plutarch (PMatch (pmatch), Term, phoistAcyclic, plam, (#), (#$), type (:-->))
+import Plutarch.Api.V1 (PMaybeData (..))
+import Plutarch.Bool (PBool, PEq ((#==)), (#<))
+import Plutarch.Builtin (PBuiltinList, PBuiltinPair, pfstBuiltin, psndBuiltin)
+import Plutarch.Extra.Maybe (pmaybeToMaybeData)
+import Plutarch.Integer (PInteger)
+import Plutarch.Lift (pconstant, plift)
+import Plutarch.Pair (PPair (..))
+
+--------------------------------------------------------------------------------
+
+import Control.Monad.Cont (cont, runCont)
+
+--------------------------------------------------------------------------------
+
+import Plutarch.Extra.Functor (pfmap)
+import Plutarch.Extra.List (pbinarySearchBy, phalve, pisUniq, pmergeBy, pmsort, pnubSort)
+
+--------------------------------------------------------------------------------
+
+tests :: [TestTree]
+tests =
+    [ testProperty "'pmsort' sorts a list properly" prop_msortCorrect
+    , testProperty "'pmerge' merges two sorted lists into one sorted list" prop_mergeCorrect
+    , testProperty "'phalve' splits a list in half as expected" prop_halveCorrect
+    , testProperty "'pnubSort' sorts a list and remove duplicate elements" prop_nubSortProperly
+    , testProperty "'pisUniq' can tell whether all elements in a list are unique" prop_uniqueList
+    , testProperty "'pbinarySearch' searches a target in a sorted list as expected" prop_binarySerchCorrect
+    ]
+
+--------------------------------------------------------------------------------
+-- Prperties.
+
+-- | Yield true if 'pmsort' sorts a given list correctly.
+prop_msortCorrect :: [Integer] -> Bool
+prop_msortCorrect l = sorted == expected
+  where
+    -- Expected sorted list, using 'Data.List.sort'.
+    expected :: [Integer]
+    expected = sort l
+
+    --
+
+    psorted :: Term s (PBuiltinList PInteger)
+    psorted = pmsort # pconstant l
+
+    sorted :: [Integer]
+    sorted = plift psorted
+
+-- | Yield true if 'pmerge' merges two list into a ordered list correctly.
+prop_mergeCorrect :: [Integer] -> [Integer] -> Bool
+prop_mergeCorrect a b = merged == expected
+  where
+    -- Sorted list a and b
+    sa = sort a
+    sb = sort b
+
+    -- Merge two lists which are assumed to be ordered.
+    merge :: [Integer] -> [Integer] -> [Integer]
+    merge xs [] = xs
+    merge [] ys = ys
+    merge sx@(x : xs) sy@(y : ys)
+        | x <= y = x : merge xs sy
+        | otherwise = y : merge sx ys
+
+    expected :: [Integer]
+    expected = merge sa sb
+
+    --
+
+    pmerged :: Term _ (PBuiltinList PInteger)
+    pmerged = pmergeBy # plam (#<) # pconstant sa # pconstant sb
+
+    merged :: [Integer]
+    merged = plift pmerged
+
+{- | Yield true if Plutarch level 'phalve' splits a given list
+   as its Haskell level counterpart does.
+-}
+prop_halveCorrect :: [Integer] -> Bool
+prop_halveCorrect l = halved == expected
+  where
+    -- Halve a list.
+    halve :: [Integer] -> ([Integer], [Integer])
+    halve xs' = go xs' xs'
+      where
+        go xs [] = ([], xs)
+        go (x : xs) [_] = ([x], xs)
+        go (x : xs) (_ : _ : ys) =
+            let (first, last) =
+                    go xs ys
+             in (x : first, last)
+        go [] _ = ([], [])
+
+    expected :: ([Integer], [Integer])
+    expected = halve l
+
+    --
+
+    phalved :: Term _ (PPair (PBuiltinList PInteger) (PBuiltinList PInteger))
+    phalved = phalve # pconstant l
+
+    halved :: ([Integer], [Integer])
+    halved =
+        let f = plift $ pmatch phalved $ \(PPair x _) -> x
+            s = plift $ pmatch phalved $ \(PPair _ x) -> x
+         in (f, s)
+
+{- | Yield true if 'pnubSort' sorts and removes
+   duplicate elements from a given list.
+-}
+prop_nubSortProperly :: [Integer] -> Bool
+prop_nubSortProperly l = nubbed == expected
+  where
+    -- Sort and list and then nub it.
+    expected :: [Integer]
+    expected = nub $ sort l
+
+    --
+
+    pnubbed :: Term _ (PBuiltinList PInteger)
+    pnubbed = pnubSort # pconstant l
+
+    nubbed :: [Integer]
+    nubbed = plift pnubbed
+
+{- | Yield true if 'isUnique' can correctly determine
+   whether a given list only contains unique elements or not.
+-}
+prop_uniqueList :: [Integer] -> Bool
+prop_uniqueList l = isUnique == expected
+  where
+    -- Convert input list to a set.
+    -- If the set's size equals to list's size,
+    --   the list only contains unique elements.
+    expected :: Bool
+    expected = S.size (S.fromList l) == length l
+
+    --
+
+    isUnique = plift $ pisUniq # pconstant l
+
+-- | Test that 'pbinarySearchBy' works as expected.
+prop_binarySerchCorrect :: Property
+prop_binarySerchCorrect =
+    runCont
+        ( do
+            -- Generate a bunch unique keys.
+            keys <-
+                cont $
+                    forAll $
+                        arbitrary @(S.Set Integer) `suchThat` (not . S.null)
+
+            -- Generate key-value pairs.
+            kvPairs <- cont $ forAll $ mapM (\k -> (k,) <$> (arbitrary @Integer)) $ S.toList keys
+
+            (targetKey, _) <- cont $ forAll $ elements kvPairs
+
+            nonexistentKey <-
+                cont $
+                    forAll $
+                        arbitrary @Integer `suchThat` (\k -> not $ S.member k keys)
+
+            pure
+                ( property (isPlutarchVersionCorrect kvPairs targetKey)
+                    .&&. property (isPlutarchVersionCorrect kvPairs nonexistentKey)
+                )
+        )
+        id
+  where
+    isPlutarchVersionCorrect :: [(Integer, Integer)] -> Integer -> Bool
+    isPlutarchVersionCorrect pairs target = native pairs target == plutarch pairs target
+
+    native :: [(Integer, Integer)] -> Integer -> Maybe Integer
+    native pairs key = M.lookup key $ M.fromList pairs
+
+    plutarch :: [(Integer, Integer)] -> Integer -> Maybe Integer
+    plutarch pairs target = plift result
+      where
+        sortedPairs = sortBy (\(a, _) (b, _) -> a `compare` b) pairs
+
+        ppairs :: Term _ (PBuiltinList (PBuiltinPair PInteger PInteger))
+        ppairs = pconstant sortedPairs
+
+        ptarget :: Term _ PInteger
+        ptarget = pconstant target
+
+        result :: Term _ (PMaybeData PInteger)
+        result = phoistAcyclic $ pmaybeToMaybeData # result'
+          where
+            comp :: Term _ (PBuiltinPair PInteger PInteger :--> PInteger :--> PBool)
+            comp = phoistAcyclic $ plam $ \((pfstBuiltin #) -> x) y -> x #< y
+
+            eq :: Term _ (PBuiltinPair PInteger PInteger :--> PInteger :--> PBool)
+            eq = phoistAcyclic $ plam $ \((pfstBuiltin #) -> x) y -> x #== y
+
+            result' =
+                pfmap # plam (\((psndBuiltin #) -> x) -> x)
+                    #$ pbinarySearchBy # eq # comp # ptarget # ppairs

--- a/test/Spec/Extra/List.hs
+++ b/test/Spec/Extra/List.hs
@@ -4,6 +4,8 @@
 
 module Spec.Extra.List (tests) where
 
+--------------------------------------------------------------------------------
+
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (
     Arbitrary (arbitrary),
@@ -29,6 +31,7 @@ import Plutarch (PMatch (pmatch), Term, phoistAcyclic, plam, (#), (#$), type (:-
 import Plutarch.Api.V1 (PMaybeData (..))
 import Plutarch.Bool (PBool, PEq ((#==)), (#<))
 import Plutarch.Builtin (PBuiltinList, PBuiltinPair, pfstBuiltin, psndBuiltin)
+import Plutarch.Extra.Functor (pfmap)
 import Plutarch.Extra.Maybe (pmaybeToMaybeData)
 import Plutarch.Integer (PInteger)
 import Plutarch.Lift (pconstant, plift)
@@ -40,7 +43,6 @@ import Control.Monad.Cont (cont, runCont)
 
 --------------------------------------------------------------------------------
 
-import Plutarch.Extra.Functor (pfmap)
 import Plutarch.Extra.List (pbinarySearchBy, phalve, pisUniq, pmergeBy, pmsort, pnubSort)
 
 --------------------------------------------------------------------------------

--- a/test/Spec/Extra/List.hs
+++ b/test/Spec/Extra/List.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Spec.Extra.List (tests) where
 
@@ -8,54 +6,38 @@ module Spec.Extra.List (tests) where
 
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (
-    Arbitrary (arbitrary),
-    Property,
-    Testable (property),
-    elements,
-    forAll,
-    suchThat,
-    testProperty,
-    (.&&.),
+  testProperty,
  )
 
 --------------------------------------------------------------------------------
 
-import Data.List (nub, sort, sortBy)
-import qualified Data.Map as M
+import Data.List (nub, sort)
 import qualified Data.Set as S
 import Prelude hiding (last)
 
 --------------------------------------------------------------------------------
 
-import Plutarch (PMatch (pmatch), Term, phoistAcyclic, plam, (#), (#$), type (:-->))
-import Plutarch.Api.V1 (PMaybeData (..))
-import Plutarch.Bool (PBool, PEq ((#==)), (#<))
-import Plutarch.Builtin (PBuiltinList, PBuiltinPair, pfstBuiltin, psndBuiltin)
-import Plutarch.Extra.Functor (pfmap)
-import Plutarch.Extra.Maybe (pmaybeToMaybeData)
+import Plutarch (Term, plam, (#))
+import Plutarch.Bool ((#<))
+import Plutarch.Builtin (PBuiltinList)
 import Plutarch.Integer (PInteger)
 import Plutarch.Lift (pconstant, plift)
-import Plutarch.Pair (PPair (..))
 
 --------------------------------------------------------------------------------
 
-import Control.Monad.Cont (cont, runCont)
-
 --------------------------------------------------------------------------------
 
-import Plutarch.Extra.List (pbinarySearchBy, phalve, pisUniq, pmergeBy, pmsort, pnubSort)
+import Plutarch.Extra.List (pisUniq, pmergeBy, pmsort, pnubSort)
 
 --------------------------------------------------------------------------------
 
 tests :: [TestTree]
 tests =
-    [ testProperty "'pmsort' sorts a list properly" prop_msortCorrect
-    , testProperty "'pmerge' merges two sorted lists into one sorted list" prop_mergeCorrect
-    , testProperty "'phalve' splits a list in half as expected" prop_halveCorrect
-    , testProperty "'pnubSort' sorts a list and remove duplicate elements" prop_nubSortProperly
-    , testProperty "'pisUniq' can tell whether all elements in a list are unique" prop_uniqueList
-    , testProperty "'pbinarySearch' searches a target in a sorted list as expected" prop_binarySerchCorrect
-    ]
+  [ testProperty "'pmsort' sorts a list properly" prop_msortCorrect
+  , testProperty "'pmerge' merges two sorted lists into one sorted list" prop_mergeCorrect
+  , testProperty "'pnubSort' sorts a list and remove duplicate elements" prop_nubSortProperly
+  , testProperty "'pisUniq' can tell whether all elements in a list are unique" prop_uniqueList
+  ]
 
 --------------------------------------------------------------------------------
 -- Prperties.
@@ -63,166 +45,76 @@ tests =
 -- | Yield true if 'pmsort' sorts a given list correctly.
 prop_msortCorrect :: [Integer] -> Bool
 prop_msortCorrect l = sorted == expected
-  where
-    -- Expected sorted list, using 'Data.List.sort'.
-    expected :: [Integer]
-    expected = sort l
+ where
+  -- Expected sorted list, using 'Data.List.sort'.
+  expected :: [Integer]
+  expected = sort l
 
-    --
+  --
 
-    psorted :: Term s (PBuiltinList PInteger)
-    psorted = pmsort # pconstant l
+  psorted :: Term s (PBuiltinList PInteger)
+  psorted = pmsort # pconstant l
 
-    sorted :: [Integer]
-    sorted = plift psorted
+  sorted :: [Integer]
+  sorted = plift psorted
 
 -- | Yield true if 'pmerge' merges two list into a ordered list correctly.
 prop_mergeCorrect :: [Integer] -> [Integer] -> Bool
 prop_mergeCorrect a b = merged == expected
-  where
-    -- Sorted list a and b
-    sa = sort a
-    sb = sort b
+ where
+  -- Sorted list a and b
+  sa = sort a
+  sb = sort b
 
-    -- Merge two lists which are assumed to be ordered.
-    merge :: [Integer] -> [Integer] -> [Integer]
-    merge xs [] = xs
-    merge [] ys = ys
-    merge sx@(x : xs) sy@(y : ys)
-        | x <= y = x : merge xs sy
-        | otherwise = y : merge sx ys
+  -- Merge two lists which are assumed to be ordered.
+  merge :: [Integer] -> [Integer] -> [Integer]
+  merge xs [] = xs
+  merge [] ys = ys
+  merge sx@(x : xs) sy@(y : ys)
+    | x <= y = x : merge xs sy
+    | otherwise = y : merge sx ys
 
-    expected :: [Integer]
-    expected = merge sa sb
+  expected :: [Integer]
+  expected = merge sa sb
 
-    --
+  --
 
-    pmerged :: Term _ (PBuiltinList PInteger)
-    pmerged = pmergeBy # plam (#<) # pconstant sa # pconstant sb
+  pmerged :: Term _ (PBuiltinList PInteger)
+  pmerged = pmergeBy # plam (#<) # pconstant sa # pconstant sb
 
-    merged :: [Integer]
-    merged = plift pmerged
-
-{- | Yield true if Plutarch level 'phalve' splits a given list
-   as its Haskell level counterpart does.
--}
-prop_halveCorrect :: [Integer] -> Bool
-prop_halveCorrect l = halved == expected
-  where
-    -- Halve a list.
-    halve :: [Integer] -> ([Integer], [Integer])
-    halve xs' = go xs' xs'
-      where
-        go xs [] = ([], xs)
-        go (x : xs) [_] = ([x], xs)
-        go (x : xs) (_ : _ : ys) =
-            let (first, last) =
-                    go xs ys
-             in (x : first, last)
-        go [] _ = ([], [])
-
-    expected :: ([Integer], [Integer])
-    expected = halve l
-
-    --
-
-    phalved :: Term _ (PPair (PBuiltinList PInteger) (PBuiltinList PInteger))
-    phalved = phalve # pconstant l
-
-    halved :: ([Integer], [Integer])
-    halved =
-        let f = plift $ pmatch phalved $ \(PPair x _) -> x
-            s = plift $ pmatch phalved $ \(PPair _ x) -> x
-         in (f, s)
+  merged :: [Integer]
+  merged = plift pmerged
 
 {- | Yield true if 'pnubSort' sorts and removes
    duplicate elements from a given list.
 -}
 prop_nubSortProperly :: [Integer] -> Bool
 prop_nubSortProperly l = nubbed == expected
-  where
-    -- Sort and list and then nub it.
-    expected :: [Integer]
-    expected = nub $ sort l
+ where
+  -- Sort and list and then nub it.
+  expected :: [Integer]
+  expected = nub $ sort l
 
-    --
+  --
 
-    pnubbed :: Term _ (PBuiltinList PInteger)
-    pnubbed = pnubSort # pconstant l
+  pnubbed :: Term _ (PBuiltinList PInteger)
+  pnubbed = pnubSort # pconstant l
 
-    nubbed :: [Integer]
-    nubbed = plift pnubbed
+  nubbed :: [Integer]
+  nubbed = plift pnubbed
 
 {- | Yield true if 'isUnique' can correctly determine
    whether a given list only contains unique elements or not.
 -}
 prop_uniqueList :: [Integer] -> Bool
 prop_uniqueList l = isUnique == expected
-  where
-    -- Convert input list to a set.
-    -- If the set's size equals to list's size,
-    --   the list only contains unique elements.
-    expected :: Bool
-    expected = S.size (S.fromList l) == length l
+ where
+  -- Convert input list to a set.
+  -- If the set's size equals to list's size,
+  --   the list only contains unique elements.
+  expected :: Bool
+  expected = S.size (S.fromList l) == length l
 
-    --
+  --
 
-    isUnique = plift $ pisUniq # pconstant l
-
--- | Test that 'pbinarySearchBy' works as expected.
-prop_binarySerchCorrect :: Property
-prop_binarySerchCorrect =
-    runCont
-        ( do
-            -- Generate a bunch unique keys.
-            keys <-
-                cont $
-                    forAll $
-                        arbitrary @(S.Set Integer) `suchThat` (not . S.null)
-
-            -- Generate key-value pairs.
-            kvPairs <- cont $ forAll $ mapM (\k -> (k,) <$> (arbitrary @Integer)) $ S.toList keys
-
-            (targetKey, _) <- cont $ forAll $ elements kvPairs
-
-            nonexistentKey <-
-                cont $
-                    forAll $
-                        arbitrary @Integer `suchThat` (\k -> not $ S.member k keys)
-
-            pure
-                ( property (isPlutarchVersionCorrect kvPairs targetKey)
-                    .&&. property (isPlutarchVersionCorrect kvPairs nonexistentKey)
-                )
-        )
-        id
-  where
-    isPlutarchVersionCorrect :: [(Integer, Integer)] -> Integer -> Bool
-    isPlutarchVersionCorrect pairs target = native pairs target == plutarch pairs target
-
-    native :: [(Integer, Integer)] -> Integer -> Maybe Integer
-    native pairs key = M.lookup key $ M.fromList pairs
-
-    plutarch :: [(Integer, Integer)] -> Integer -> Maybe Integer
-    plutarch pairs target = plift result
-      where
-        sortedPairs = sortBy (\(a, _) (b, _) -> a `compare` b) pairs
-
-        ppairs :: Term _ (PBuiltinList (PBuiltinPair PInteger PInteger))
-        ppairs = pconstant sortedPairs
-
-        ptarget :: Term _ PInteger
-        ptarget = pconstant target
-
-        result :: Term _ (PMaybeData PInteger)
-        result = phoistAcyclic $ pmaybeToMaybeData # result'
-          where
-            comp :: Term _ (PBuiltinPair PInteger PInteger :--> PInteger :--> PBool)
-            comp = phoistAcyclic $ plam $ \((pfstBuiltin #) -> x) y -> x #< y
-
-            eq :: Term _ (PBuiltinPair PInteger PInteger :--> PInteger :--> PBool)
-            eq = phoistAcyclic $ plam $ \((pfstBuiltin #) -> x) y -> x #== y
-
-            result' =
-                pfmap # plam (\((psndBuiltin #) -> x) -> x)
-                    #$ pbinarySearchBy # eq # comp # ptarget # ppairs
+  isUnique = plift $ pisUniq # pconstant l

--- a/test/Spec/Extra/Map.hs
+++ b/test/Spec/Extra/Map.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Spec.Extra.Map (tests) where
+
+--------------------------------------------------------------------------------
+
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (
+    Arbitrary (arbitrary),
+    Property,
+    Testable (property),
+    elements,
+    forAll,
+    suchThat,
+    testProperty,
+    (.&&.),
+ )
+
+--------------------------------------------------------------------------------
+
+import qualified Data.Map as M
+import qualified Data.Set as S
+
+--------------------------------------------------------------------------------
+
+import Plutarch (PCon (pcon), Term, phoistAcyclic, plam, (#))
+import Plutarch.Integer (PInteger)
+import Plutarch.Lift (pconstant, plift)
+import Plutarch.Maybe (PMaybe (..))
+import qualified PlutusTx.AssocMap as AssocMap
+
+--------------------------------------------------------------------------------
+
+import Control.Monad.Cont (cont, runCont)
+
+--------------------------------------------------------------------------------
+
+import Plutarch.Extra.Map (pupdate, update)
+
+--------------------------------------------------------------------------------
+
+tests :: [TestTree]
+tests = [testProperty "'pupdate' updates assoc maps as 'update' does" prop_updateAssocMapParity]
+
+--------------------------------------------------------------------------------
+
+{- | Test the parity between 'update' and 'pupdate',
+     also ensure they both work correctly.
+-}
+prop_updateAssocMapParity :: Property
+prop_updateAssocMapParity =
+    runCont
+        ( do
+            -- Generate a bunch unique keys.
+            keys <-
+                cont $
+                    forAll $
+                        arbitrary @(S.Set Integer) `suchThat` (not . S.null)
+
+            -- Generate key-value pairs.
+            kvPairs <- cont $ forAll $ mapM (\k -> (k,) <$> (arbitrary @Integer)) $ S.toList keys
+
+            let initialMap = AssocMap.fromList kvPairs
+
+                pinitialMap :: Term _ _
+                pinitialMap = phoistAcyclic $ pconstant initialMap
+
+                referenceMap = M.fromList kvPairs
+
+            let pupdatedValue :: Maybe Integer -> Term _ (PMaybe PInteger)
+                pupdatedValue updatedValue = phoistAcyclic $ case updatedValue of
+                    Nothing -> pcon PNothing
+                    Just v -> pcon $ PJust $ pconstant v
+
+                -- Given the key and the updated value, test the parity
+                parity key updatedValue =
+                    let native = update (const updatedValue) key initialMap
+
+                        plutarch :: AssocMap.Map Integer Integer
+                        plutarch =
+                            plift $
+                                pupdate
+                                    # plam (\_ -> pupdatedValue updatedValue)
+                                    # pconstant key
+                                    # pinitialMap
+
+                        expected =
+                            AssocMap.fromList $
+                                M.toList $
+                                    M.update (const updatedValue) key referenceMap
+                     in expected == native
+                            && expected == plutarch
+
+            -- Select a key, generate a maybe value.
+            -- The value at the key should be set to the new value or removed.
+            (targetKey, _) <- cont $ forAll $ elements kvPairs
+            updatedValue <- cont $ forAll $ arbitrary @(Maybe Integer)
+
+            -- Now what if the key doesn't exist in our map?
+            nonexistentKey <-
+                cont $
+                    forAll $
+                        arbitrary @Integer `suchThat` (\k -> not $ S.member k keys)
+
+            pure
+                ( property (parity targetKey updatedValue)
+                    .&&. property (parity nonexistentKey updatedValue)
+                )
+        )
+        id

--- a/test/Spec/Extra/Map/Sorted.hs
+++ b/test/Spec/Extra/Map/Sorted.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Spec.Extra.Map.Sorted (tests) where
+
+--------------------------------------------------------------------------------
+
+import Spec.Utils (genKeySet, genNonIdenticalKeySets, genSortedMapWithKeys)
+import Test.QuickCheck (
+    Gen,
+    Property,
+    shrinkNothing,
+ )
+import Test.Tasty (TestTree)
+import Test.Tasty.Plutarch.Property (classifiedPropertyNative, peqPropertyNative')
+import Test.Tasty.QuickCheck (
+    testProperty,
+ )
+
+--------------------------------------------------------------------------------
+
+import qualified Data.Map as M
+import Data.Universe (Finite, Universe)
+import qualified GHC.Generics as GHC
+
+--------------------------------------------------------------------------------
+
+import Plutarch (Term, phoistAcyclic, plam, (#), type (:-->))
+import Plutarch.Api.V1.AssocMap (KeyGuarantees (..), PMap)
+import Plutarch.Bool (PBool)
+import Plutarch.Builtin (PBuiltinPair, pfstBuiltin, psndBuiltin)
+import Plutarch.Integer (PInteger)
+import Plutarch.Unsafe (punsafeCoerce)
+import qualified PlutusTx.AssocMap as AssocMap
+
+--------------------------------------------------------------------------------
+
+import Plutarch.Extra.Map.Sorted (pkeysEqual, punionWith)
+
+--------------------------------------------------------------------------------
+
+tests :: [TestTree]
+tests =
+    [ testProperty "'pkeysEquals' can tell whether two maps have the same key set or not" prop_keysEqualCorrect
+    , testProperty "'punionWith' merges two sorted map correctly" prop_unionMapsCorrect
+    ]
+
+--------------------------------------------------------------------------------
+
+data KeysEqualCase = KeysAreEqual | KeysAreNotEqual
+    deriving stock (GHC.Generic)
+    deriving stock (Show, Enum, Bounded, Eq)
+    deriving anyclass (Universe, Finite)
+
+-- | The property of 'pkeysEqual' to determine whether two maps have the same keys or not.
+prop_keysEqualCorrect :: Property
+prop_keysEqualCorrect = classifiedPropertyNative generator shrinkNothing expected classifier definition
+  where
+    generator ::
+        KeysEqualCase ->
+        Gen (AssocMap.Map Integer Integer, AssocMap.Map Integer Integer)
+    generator = \case
+        KeysAreEqual -> do
+            keys <- genKeySet
+            a <- genSortedMapWithKeys keys
+            b <- genSortedMapWithKeys keys
+            return (a, b)
+        KeysAreNotEqual -> do
+            (ka, kb) <- genNonIdenticalKeySets
+            (,)
+                <$> genSortedMapWithKeys ka
+                <*> genSortedMapWithKeys kb
+
+    expected :: (AssocMap.Map Integer Integer, AssocMap.Map Integer Integer) -> Maybe Bool
+    expected (AssocMap.keys -> a, AssocMap.keys -> b) = Just $ a == b
+
+    classifier :: (AssocMap.Map Integer Integer, AssocMap.Map Integer Integer) -> KeysEqualCase
+    classifier (AssocMap.keys -> a, AssocMap.keys -> b)
+        | a == b = KeysAreEqual
+        | otherwise = KeysAreNotEqual
+
+    definition ::
+        Term
+            _
+            ( PBuiltinPair
+                (PMap 'Unsorted PInteger PInteger)
+                (PMap 'Unsorted PInteger PInteger)
+                :--> PBool
+            )
+    definition = phoistAcyclic $
+        plam $ \pair ->
+            let a :: Term _ (PMap 'Sorted PInteger PInteger)
+                a = punsafeCoerce $ pfstBuiltin # pair
+
+                b :: Term _ (PMap 'Sorted PInteger PInteger)
+                b = punsafeCoerce $ psndBuiltin # pair
+             in pkeysEqual # a # b
+
+--------------------------------------------------------------------------------
+
+-- | The property of 'punionMap' to merge two maps into one sorted map correctly.
+prop_unionMapsCorrect :: Property
+prop_unionMapsCorrect = peqPropertyNative' expected generator shrinkNothing definition
+  where
+    generator ::
+        Gen (AssocMap.Map Integer Integer, AssocMap.Map Integer Integer)
+    generator = do
+        keysA <- genKeySet
+        keysB <- genKeySet
+        (,)
+            <$> genSortedMapWithKeys keysA
+            <*> genSortedMapWithKeys keysB
+
+    expected ::
+        ( AssocMap.Map Integer Integer
+        , AssocMap.Map Integer Integer
+        ) ->
+        AssocMap.Map Integer Integer
+    expected (AssocMap.toList -> a, AssocMap.toList -> b) =
+        let ma = M.fromList a
+            mb = M.fromList b
+
+            unionF :: Integer -> Integer -> Integer
+            unionF = (+)
+
+            mu = M.unionWith unionF ma mb
+         in AssocMap.fromList $ M.toList mu
+
+    definition ::
+        Term
+            _
+            ( PBuiltinPair
+                (PMap 'Unsorted PInteger PInteger)
+                (PMap 'Unsorted PInteger PInteger)
+                :--> PMap 'Unsorted PInteger PInteger
+            )
+    definition = phoistAcyclic $
+        plam $ \pair ->
+            let a :: Term _ (PMap 'Sorted PInteger PInteger)
+                a = punsafeCoerce $ pfstBuiltin # pair
+
+                b :: Term _ (PMap 'Sorted PInteger PInteger)
+                b = punsafeCoerce $ psndBuiltin # pair
+
+                unionF :: Term _ (PInteger :--> PInteger :--> PInteger)
+                unionF = phoistAcyclic $ plam (+)
+             in punsafeCoerce $ punionWith # unionF # a # b

--- a/test/Spec/Extra/Map/Unsorted.hs
+++ b/test/Spec/Extra/Map/Unsorted.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Spec.Extra.Map.Unsorted (tests) where
+
+--------------------------------------------------------------------------------
+
+import Spec.Utils (
+    genKeySet,
+    genNonIdenticalKeySets,
+    genSortedMapWithKeys,
+    genUnsortedMapWithKeys,
+    shrinkMap,
+    sortMap,
+ )
+import Test.QuickCheck (
+    Gen,
+    Property,
+    shrinkNothing,
+ )
+import Test.Tasty (TestTree)
+import Test.Tasty.Plutarch.Property (classifiedPropertyNative, peqPropertyNative')
+import Test.Tasty.QuickCheck (
+    testProperty,
+ )
+
+--------------------------------------------------------------------------------
+
+import qualified Data.Map as M
+import Data.Universe (Finite, Universe)
+import qualified GHC.Generics as GHC
+
+--------------------------------------------------------------------------------
+
+import Plutarch (Term, phoistAcyclic, plam, (#), type (:-->))
+import Plutarch.Api.V1.AssocMap (KeyGuarantees (..), PMap)
+import Plutarch.Bool (PBool)
+import Plutarch.Builtin (PBuiltinPair, pfstBuiltin, psndBuiltin)
+import Plutarch.Integer (PInteger)
+import Plutarch.Unsafe (punsafeCoerce)
+import qualified PlutusTx.AssocMap as AssocMap
+
+--------------------------------------------------------------------------------
+
+import Plutarch.Extra.Map.Unsorted (pkeysEqual, psort, punionWith)
+
+--------------------------------------------------------------------------------
+
+tests :: [TestTree]
+tests =
+    [ testProperty "'pkeysEquals' can tell whether two maps have the same key set or not" prop_keysEqualCorrect
+    , testProperty "'punionWith' merges two sorted maps correctly" prop_unionMapsCorrect
+    , testProperty "'psort' sorts unsorted maps as expcted" prop_psortCorrect
+    ]
+
+--------------------------------------------------------------------------------
+
+-- | The property of 'psort' to make an unsorted map sorted.
+prop_psortCorrect :: Property
+prop_psortCorrect = peqPropertyNative' sortMap generator shrinkMap definition
+  where
+    generator :: Gen (AssocMap.Map Integer Integer)
+    generator = genKeySet >>= genUnsortedMapWithKeys
+
+    definition :: Term _ (PMap 'Unsorted PInteger PInteger :--> PMap 'Unsorted PInteger PInteger)
+    definition = phoistAcyclic $ plam $ \m -> punsafeCoerce $ psort # m
+
+--------------------------------------------------------------------------------
+
+data KeysEqualCase = KeysAreEqual | KeysAreNotEqual
+    deriving stock (GHC.Generic)
+    deriving stock (Show, Enum, Bounded, Eq)
+    deriving anyclass (Universe, Finite)
+
+-- | The property of 'pkeysEqual' to determine whether two maps have the same keys or not.
+prop_keysEqualCorrect :: Property
+prop_keysEqualCorrect = classifiedPropertyNative generator shrinkNothing expected classifier definition
+  where
+    generator ::
+        KeysEqualCase ->
+        Gen (AssocMap.Map Integer Integer, AssocMap.Map Integer Integer)
+    generator = \case
+        KeysAreEqual -> do
+            keys <- genKeySet
+            a <- genSortedMapWithKeys keys
+            b <- genSortedMapWithKeys keys
+            return (a, b)
+        KeysAreNotEqual -> do
+            (ka, kb) <- genNonIdenticalKeySets
+            (,)
+                <$> genSortedMapWithKeys ka
+                <*> genSortedMapWithKeys kb
+
+    expected :: (AssocMap.Map Integer Integer, AssocMap.Map Integer Integer) -> Maybe Bool
+    expected (AssocMap.keys -> a, AssocMap.keys -> b) = Just $ a == b
+
+    classifier :: (AssocMap.Map Integer Integer, AssocMap.Map Integer Integer) -> KeysEqualCase
+    classifier (AssocMap.keys -> a, AssocMap.keys -> b)
+        | a == b = KeysAreEqual
+        | otherwise = KeysAreNotEqual
+
+    definition ::
+        Term
+            _
+            ( PBuiltinPair
+                (PMap 'Unsorted PInteger PInteger)
+                (PMap 'Unsorted PInteger PInteger)
+                :--> PBool
+            )
+    definition = phoistAcyclic $
+        plam $ \pair ->
+            let a = pfstBuiltin # pair
+                b = psndBuiltin # pair
+             in pkeysEqual # a # b
+
+--------------------------------------------------------------------------------
+
+-- | The property of 'punionMap' to merge two maps into one sorted map correctly.
+prop_unionMapsCorrect :: Property
+prop_unionMapsCorrect = peqPropertyNative' expected generator shrinkNothing definition
+  where
+    generator ::
+        Gen (AssocMap.Map Integer Integer, AssocMap.Map Integer Integer)
+    generator = do
+        keysA <- genKeySet
+        keysB <- genKeySet
+        (,)
+            <$> genSortedMapWithKeys keysA
+            <*> genSortedMapWithKeys keysB
+
+    expected ::
+        ( AssocMap.Map Integer Integer
+        , AssocMap.Map Integer Integer
+        ) ->
+        AssocMap.Map Integer Integer
+    expected (AssocMap.toList -> a, AssocMap.toList -> b) =
+        let ma = M.fromList a
+            mb = M.fromList b
+
+            unionF :: Integer -> Integer -> Integer
+            unionF = (+)
+
+            mu = M.unionWith unionF ma mb
+         in AssocMap.fromList $ M.toList mu
+
+    definition ::
+        Term
+            _
+            ( PBuiltinPair
+                (PMap 'Unsorted PInteger PInteger)
+                (PMap 'Unsorted PInteger PInteger)
+                :--> PMap 'Unsorted PInteger PInteger
+            )
+    definition = phoistAcyclic $
+        plam $ \pair ->
+            let a = pfstBuiltin # pair
+                b = psndBuiltin # pair
+
+                unionF :: Term _ (PInteger :--> PInteger :--> PInteger)
+                unionF = phoistAcyclic $ plam (+)
+             in punsafeCoerce $ punionWith # unionF # a # b

--- a/test/Spec/Utils.hs
+++ b/test/Spec/Utils.hs
@@ -33,9 +33,9 @@ import Test.QuickCheck (
     Gen,
     chooseAny,
     listOf,
+    oneof,
     shuffle,
     suchThat,
-    oneof
  )
 
 -- | Generate a set of unique keys.

--- a/test/Spec/Utils.hs
+++ b/test/Spec/Utils.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Spec.Utils (
+    genKeySet,
+    genSortedMapWithKeys,
+    genUnsortedMapWithKeys,
+    genNonIdenticalKeySets,
+    shrinkMap,
+    genSingletonValue,
+    sortMap,
+    sortValue,
+    genValue,
+) where
+
+import qualified Data.Bifunctor as Bifunctor
+import qualified Data.ByteString.Char8 as C (ByteString, pack)
+import Data.ByteString.Hash (sha2_256)
+import Data.List (sortBy)
+import qualified Data.Set as S
+import PlutusLedgerApi.V1 (
+    BuiltinByteString,
+    CurrencySymbol (..),
+    TokenName (..),
+    Value (..),
+    toBuiltin,
+ )
+import PlutusLedgerApi.V1.Value (AssetClass (..))
+import qualified PlutusLedgerApi.V1.Value as Value
+import qualified PlutusTx.AssocMap as AssocMap
+import Test.QuickCheck (
+    Arbitrary (arbitrary, shrink),
+    Gen,
+    chooseAny,
+    listOf,
+    shuffle,
+    suchThat,
+    oneof
+ )
+
+-- | Generate a set of unique keys.
+genKeySet :: (Ord k, Arbitrary k) => Gen (S.Set k)
+genKeySet = arbitrary
+
+-- | Generate a map given a key set.
+genSortedMapWithKeys :: (Arbitrary v) => S.Set k -> Gen (AssocMap.Map k v)
+genSortedMapWithKeys keys =
+    AssocMap.fromList <$> mapM (\k -> (k,) <$> arbitrary) (S.toAscList keys)
+
+-- | Generate an unsorted map given a key set.
+genUnsortedMapWithKeys :: (Arbitrary v) => S.Set k -> Gen (AssocMap.Map k v)
+genUnsortedMapWithKeys keys = do
+    kl <- shuffle $ S.toList keys
+    kvs <-
+        mapM
+            (\k -> (k,) <$> arbitrary)
+            kl
+    return $ AssocMap.fromList kvs
+
+-- | Generate a pair of unidentical key sets.
+genNonIdenticalKeySets ::
+    (Ord k, Arbitrary k) =>
+    Gen (S.Set k, S.Set k)
+genNonIdenticalKeySets = do
+    a <- genKeySet
+    b <- genKeySet `suchThat` (/= a)
+    return (a, b)
+
+-- |c Shrinker for associative maps.
+shrinkMap :: (Arbitrary k, Arbitrary v) => AssocMap.Map k v -> [AssocMap.Map k v]
+shrinkMap (AssocMap.toList -> l) = AssocMap.fromList <$> shrink l
+
+-- | Sort a map in ascending order.
+sortMap :: (Ord k) => AssocMap.Map k v -> AssocMap.Map k v
+sortMap (AssocMap.toList -> l) =
+    AssocMap.fromList $ sortBy (\(ka, _) (kb, _) -> compare ka kb) l
+
+{- | Generate a random Hash
+Hashs cannot be shrunken; functions utilizing this function,
+therefore, cannot be shrunken as well.
+
+Note: copy-paste from https://github.com/Liqwid-Labs/agora/blob/main/agora-specs/Property/Generator.hs
+-}
+genHashByteString :: Gen C.ByteString
+genHashByteString = sha2_256 . C.pack . show <$> (chooseAny @Integer)
+
+-- | Generate a 'BuiltinByteString'.
+genBuiltinByteString :: Gen BuiltinByteString
+genBuiltinByteString = toBuiltin <$> genHashByteString
+
+-- | Generate a valid 'CurrencySymbol'.
+genCurrencySymbol :: Gen CurrencySymbol
+genCurrencySymbol = CurrencySymbol <$> oneof [genBuiltinByteString, pure ""]
+
+-- | Generate a valid 'TokenName'.
+genTokenName :: Gen TokenName
+genTokenName = TokenName <$> oneof [genBuiltinByteString, pure ""]
+
+-- | Generate a valid 'AssetClass'.
+genAssetClass :: Gen AssetClass
+genAssetClass = AssetClass <$> ((,) <$> genCurrencySymbol <*> genTokenName)
+
+-- | Generate a 'Value' that only contains positive amount of the given 'AssetClass'.
+genSingletonValue :: Gen Value
+genSingletonValue = Value.assetClassValue <$> genAssetClass <*> (arbitrary `suchThat` (> 0))
+
+-- | Generate a 'Value'.
+genValue :: Gen Value
+genValue = mconcat <$> listOf genSingletonValue
+
+-- | Sort a 'Value'. The inner tokename-amount map will be sorted as well.
+sortValue :: Value -> Value
+sortValue (Value.getValue -> inner) = Value $ sortMap sortedInner
+  where
+    sortedInner =
+        AssocMap.fromList $
+            map (Bifunctor.second sortMap) $
+                AssocMap.toList inner


### PR DESCRIPTION
Will close #6.

Here is the manifest:

## AssocMap 

* `Plutarch.Extra.Map`

- [x] `pupdate`
- [x] `pmapMap` -> `pmap`
- [x] `update` (Haskell-level `pupdate`)

* `Plutarch.Extra.Map.Sorted`

- [x] `pkeysEqual`
- [x] `pmapUnionWith` -> `punionWith`

* `Plutarch.Extra.Map.Unsorted`

- [x] `psort` 
- [x] `pkeysEqual`
- [x] `pmapUnionWith` -> `punionWith`

### Tests

- [x] `pkeysEqual`
- [x] `punionWith`
- [x] `psortMap` 
- [x] `pupdate`/`update`
- [x] `pmap`

## Value 

* `Plutarch.Api.V1.Value`

- [x] `psymbolValueOf`
- [x] `passetClassValueOf'`
- [x] `pgeqByClass`
- [x] `pgeqByClass'`
- [x] `pgeqBySymbol`

* `Plutarch.Api.V1.Value.Unsorted`

- [x] `psort`
- [x] ~~`paddValue` -> `padd`~~ Use semigroup

## Maybe (`Plutarch.Extra.Maybe`)

- [x] `pisJust`
- [x] `pisDJust`
- [x] `pfromMaybe`  -> `pmaybe`
- [x] `tcexpectJust` -> `pexpectJustC`
- [x] `pmaybeToMaybeData`

## List (`Plutarch.Extra.List`)

- [x] Re-export stuff from `plutarch-extra`
- [x] `pnotNull`
- [x] `pnubSortBy`/`pnubSort`
- [x] `pisUniqueBy`/`pisUnique`
- [x] `pmergeBy`
- [x] `pmsortBy`/`pmsort`
- [x] `pfindMap`->`pfirstJust`
- [x] `plookup`
- [x] `plookupTuple`
- [x] `pfind'`
- [x] `pfindMap` -> `pfirstJust`

### Tests

- [x] `pmsort`
- [x] `phalve`
- [x] `pmerge`
- [x] `pnubSort`
- [x] `pisUnique`
- [x] `pbinarySearchBy`

## `TermCont` (`Plutarch.Extra.TermCont`)

- [x] Re-export stuff from `plutarch-extra` 
- [x] `tcassert` -> `passertC`
- [x] ~~`tctryFrom` -> `ptryFromC`~~ Already in `plutarch-extra`

## Script Context (`Plutarch.Api.V1.ScriptContext`)

- [x] `ptokenSpent` -> `pisTokenSpent`
- [x] `pisUTXOSpent `
- [x] `pvalueSpent `
- [x] `ptxSignedBy `
- [x] `ptryFindDatum `
- [x] `pfindDatum `

Some other TODOs

- [x] Doc string
- [x] `eqPropertyNative'`