### PR TITLE
Add release changelog and 'pguardWithC' function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 - `pupdate`
 - `pmapMap` -> `pmap`
-- `update` (Haskell-level `pupdate`)
 
 #### AssocMap (`Plutarch.Extra.Map.Sorted`)
 
@@ -79,3 +78,4 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 - `ptxSignedBy`
 - `ptryFindDatum`
 - `pfindDatum`
+- `pfindTxInByTxOutRef`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,73 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 ### Added
 
 * First release
+
+## 1.1.0 -- 2022-06-17
+
+### Added
+
+#### AssocMap (`Plutarch.Extra.Map`)
+
+- `pupdate`
+- `pmapMap` -> `pmap`
+- `update` (Haskell-level `pupdate`)
+
+#### AssocMap (`Plutarch.Extra.Map.Sorted`)
+
+- `pkeysEqual`
+- `pmapUnionWith` -> `punionWith`
+
+#### AssocMap (`Plutarch.Extra.Map.Unsorted`)
+
+- `psort` 
+- `pkeysEqual`
+- `pmapUnionWith` -> `punionWith`
+
+#### Value (`Plutarch.Api.V1.Value`)
+
+- `psymbolValueOf`
+- `passetClassValueOf'`
+- `pgeqByClass`
+- `pgeqByClass'`
+- `pgeqBySymbol`
+
+#### Value (`Plutarch.Api.V1.Value.Unsorted`)
+
+- `psort`
+
+#### Maybe (`Plutarch.Extra.Maybe`)
+
+- `pisJust`
+- `pisDJust`
+- `pfromMaybe`  -> `pmaybe`
+- `tcexpectJust` -> `pexpectJustC`
+- `pmaybeToMaybeData`
+
+#### List (`Plutarch.Extra.List`)
+
+- Re-exports from `plutarch-extra`
+- `pnotNull`
+- `pnubSortBy`/`pnubSort`
+- `pisUniqueBy`/`pisUnique`
+- `pmergeBy`
+- `pmsortBy`/`pmsort`
+- `pfindMap`->`pfirstJust`
+- `plookup`
+- `plookupTuple`
+- `pfind'`
+- `pfindMap` -> `pfirstJust`
+
+#### `TermCont` (`Plutarch.Extra.TermCont`)
+
+- Re-exports from `plutarch-extra` 
+- `tcassert` -> `passertC`
+- `pguardWithC`
+
+#### Script Context (`Plutarch.Api.V1.ScriptContext`)
+
+- `ptokenSpent` -> `pisTokenSpent`
+- `pisUTXOSpent`
+- `pvalueSpent`
+- `ptxSignedBy`
+- `ptryFindDatum`
+- `pfindDatum`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 - `pisJust`
 - `pisDJust`
 - `pfromMaybe`  -> `pmaybe`
-- `tcexpectJust` -> `pexpectJustC`
+- `tcexpectJust` (in `Plutarch.Extra.Maybe`) -> `pexpectJustC` (in `Plutarch.Extra.TermCont`)
 - `pmaybeToMaybeData`
 
 #### List (`Plutarch.Extra.List`)
@@ -68,6 +68,8 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 - Re-exports from `plutarch-extra` 
 - `tcassert` -> `passertC`
 - `pguardWithC`
+- 'pguardShowC'
+- `tcexpectJust` (in `Plutarch.Extra.Maybe`) -> `pexpectJustC` (in `Plutarch.Extra.TermCont`)
 
 #### Script Context (`Plutarch.Api.V1.ScriptContext`)
 

--- a/src/Plutarch/Extra/Maybe.hs
+++ b/src/Plutarch/Extra/Maybe.hs
@@ -137,20 +137,3 @@ pmaybeToMaybeData = phoistAcyclic $
     plam $ \t -> pmatch t $ \case
         PNothing -> pcon $ PDNothing pdnil
         PJust x -> pcon $ PDJust $ pdcons @"_0" # pdata x # pdnil
-
---------------------------------------------------------------------------------
--- TermCont-based combinators.
-
-{- | Escape with a particular value on expecting 'Just'. For use in monadic context.
-
-    @since 1.1.0
--}
-pexpectJustC ::
-    forall (a :: S -> Type) (r :: S -> Type) (s :: S).
-    Term s r ->
-    Term s (PMaybe a) ->
-    TermCont @r s (Term s a)
-pexpectJustC escape ma = tcont $ \f ->
-    pmatch ma $ \case
-        PJust v -> f v
-        PNothing -> escape

--- a/src/Plutarch/Extra/TermCont.hs
+++ b/src/Plutarch/Extra/TermCont.hs
@@ -1,4 +1,10 @@
-module Plutarch.Extra.TermCont (module Extra) where
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Plutarch.Extra.TermCont (
+    module Extra,
+    pguardWithC,
+) where
 
 import "plutarch-extra" Plutarch.Extra.TermCont as Extra (
     pguardC,
@@ -9,3 +15,31 @@ import "plutarch-extra" Plutarch.Extra.TermCont as Extra (
     ptraceC,
     ptryFromC,
  )
+import Plutarch.Prelude
+
+{- | 'pguardC' but with type threading for better traces.
+
+  == Example
+
+  Typical 'pguard' usage:
+
+  @'pguardC' "foo should be even" ('Plutarch.Extra.Numeric.peven' # foo)@
+
+  This is great, but won't tell us what @foo@ _is_, when it isn't even.
+  Thankfully, we can augment this using 'pguardWithC':
+
+  @'pguardWithC' (\x -> "foo should be even. it was " <> pshow x) ('peven' #) foo@
+
+  @since 1.1.0
+-}
+pguardWithC ::
+    forall (r :: PType) (pt :: PType) (s :: S).
+    -- | Function to print in case of guard failure.
+    --   Only gets included in binary when compiling with @development@ flag.
+    (Term s pt -> Term s PString) ->
+    -- | Function to check for validity of element. Always gets included in script binary.
+    (Term s pt -> Term s PBool) ->
+    Term s pt ->
+    TermCont @r s ()
+pguardWithC tracer checker object =
+    pguardC (tracer object) (checker object)


### PR DESCRIPTION
Summary: Updated CHANGELOG.md with the new 1.1.0 release and added `pguardWithC` function for some more aggressive traces.

I suppose if we want to create proper releases we really ought to use a `staging`.