### PR TITLE
Added Extra.IsData module 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ result
 result-*
 
 # direnv
-#.envrc
+.envrc
 .direnv
 
 *.sw*

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -79,6 +79,7 @@ library
     Plutarch.Extra.Function
     Plutarch.Extra.Functor
     Plutarch.Extra.Identity
+    Plutarch.Extra.IsData
     Plutarch.Extra.List
     Plutarch.Extra.Map
     Plutarch.Extra.Map.Sorted

--- a/src/Plutarch/Extra/IsData.hs
+++ b/src/Plutarch/Extra/IsData.hs
@@ -52,19 +52,29 @@ import Prelude
   Wrapper for deriving 'ToData', 'FromData' using the 'List' constructor of Data to represent a Product type.
 
   Uses 'gProductToBuiltinData', 'gproductFromBuiltinData'.
+
+  @since 1.1.0
 -}
 newtype ProductIsData a = ProductIsData {unProductIsData :: a}
 
 -- | Variant of 'PConstantViaData' using the List repr from 'ProductIsData'
 newtype PConstantViaDataList (h :: Type) (p :: PType) = PConstantViaDataList h
 
--- | Generically convert a Product-Type to 'BuiltinData' with the 'List' repr
+{- |
+  Generically convert a Product-Type to 'BuiltinData' with the 'List' repr.
+
+  @since 1.1.0
+-}
 gProductToBuiltinData ::
     (IsProductType a repr, All ToData repr) => a -> BuiltinData
 gProductToBuiltinData x =
     BuiltinData $ List $ hcollapse $ hcmap (Proxy @ToData) (mapIK toData) $ productTypeFrom x
 
--- | Generically convert a Product-type from a 'BuiltinData' 'List' repr
+{- |
+  Generically convert a Product-type from a 'BuiltinData' 'List' repr.
+
+  @since 1.1.0
+-}
 gProductFromBuiltinData ::
     forall (a :: Type) (repr :: [Type]).
     (IsProductType a repr, All FromData repr) =>
@@ -95,10 +105,18 @@ instance (IsProductType a repr, All FromData repr) => FromData (ProductIsData a)
 --------------------------------------------------------------------------------
 -- PEnumData
 
--- | Wrapper for deriving 'ToData', 'FromData' using an Integer representation via 'Enum'
+{- |
+  Wrapper for deriving 'ToData', 'FromData' using an Integer representation via 'Enum'.
+
+  @since 1.1.0
+-}
 newtype EnumIsData a = EnumIsData a
 
--- | Wrapper for deriving `PlutusType` & `PIsData` via a ToData repr derived with `EnumIsData`
+{- |
+  Wrapper for deriving `PlutusType` & `PIsData` via a ToData repr derived with `EnumIsData`.
+
+  @since 1.1.0
+-}
 newtype PEnumData (a :: PType) (s :: S) = PEnumData (a s)
     deriving (Enum, Bounded) via (a s)
 
@@ -125,7 +143,11 @@ instance forall (a :: PType). PIsData (PEnumData a) where
     pdataImpl x =
         pdataImpl $ pto x
 
--- | Pattern match over the integer-repr of a Bounded Enum type
+{- |
+  Pattern match over the integer-repr of a Bounded Enum type.
+
+  @since 1.1.0
+-}
 pmatchEnum ::
     forall (a :: Type) (b :: PType) (s :: S).
     (Bounded a, Enum a) =>
@@ -146,7 +168,11 @@ pmatchEnum x f = unTermCont $ do
 
     pure $ foldr branch (f maxBound) cases
 
--- | Pattern match PData as a Bounded Enum. Useful for Redeemers
+{- |
+  Pattern match PData as a Bounded Enum. Useful for Redeemers.
+
+  @since 1.1.0
+-}
 pmatchEnumFromData ::
     forall (a :: Type) (b :: PType) (s :: S).
     (Bounded a, Enum a) =>

--- a/src/Plutarch/Extra/IsData.hs
+++ b/src/Plutarch/Extra/IsData.hs
@@ -85,6 +85,7 @@ gProductFromBuiltinData (BuiltinData (List xs)) = do
     productTypeTo <$> hctraverse (Proxy @FromData) (unI . mapKI fromData) prod
 gProductFromBuiltinData _ = Nothing
 
+-- | @since 1.1.0
 instance
     (PlutusTx.FromData h, PlutusTx.ToData h, PLift p) =>
     PConstantDecl (PConstantViaDataList h p)
@@ -96,9 +97,11 @@ instance
         _ -> error "ToData repr is not a List!"
     pconstantFromRepr = coerce (PlutusTx.fromData @h . PlutusTx.List)
 
+-- | @since 1.1.0
 instance (IsProductType a repr, All ToData repr) => ToData (ProductIsData a) where
     toBuiltinData = coerce (gProductToBuiltinData @a)
 
+-- | @since 1.1.0
 instance (IsProductType a repr, All FromData repr) => FromData (ProductIsData a) where
     fromBuiltinData = coerce (gProductFromBuiltinData @a)
 
@@ -118,14 +121,23 @@ newtype EnumIsData a = EnumIsData a
   @since 1.1.0
 -}
 newtype PEnumData (a :: PType) (s :: S) = PEnumData (a s)
-    deriving (Enum, Bounded) via (a s)
+    deriving
+        ( -- | @since 1.1.0
+          Enum
+        , -- | @since 1.1.0
+          Bounded
+        )
+        via (a s)
 
+-- | @since 1.1.0
 instance (Enum a) => ToData (EnumIsData a) where
     toBuiltinData = coerce $ toBuiltinData . toInteger . fromEnum @a
 
+-- | @since 1.1.0
 instance (Enum a) => FromData (EnumIsData a) where
     fromBuiltinData = coerce $ fmap (toEnum @a . fromInteger) . fromBuiltinData @Integer
 
+-- | @since 1.1.0
 instance
     ( forall s. Enum (a s)
     , forall s. Bounded (a s)
@@ -136,6 +148,7 @@ instance
     pmatch' = pmatchEnum
     pcon' = fromInteger . toInteger . fromEnum
 
+-- | @since 1.1.0
 instance forall (a :: PType). PIsData (PEnumData a) where
     pfromDataImpl d =
         punsafeCoerce (pfromDataImpl @PInteger $ punsafeCoerce d)


### PR DESCRIPTION
- `ProductIsData` & the corresponding `PConstantViaDataList` for deriving ToData/FromData/PLift/PConstant/PIsData for record types using the List constructor
- `EnumIsData` & the corresponding `PEnumData` for deriving ToData/FromData/PLift/PConstant/PIsData for Enum types using the PInteger constructor
- `pmatchEnum` & `pmatchEnumFromData` helpers for enums