### PR TITLE
Traversable improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 1.2.0 -- 2022-07-12
+
+### Added
+
+- `PBoring` type class, representing singleton types.
+- Instances of `PBoring` for various types.
+- `preconst` for `PConst`, which allows safe coercions between different
+  'pretend' types.
+- `PSemiTraversable` instance for `PTagged`.
+
+### Modified
+
+- `PFunctor` now has a `pfconst` method as a back-end for `#$>` and `#<$`. This
+  has a default implementation in terms of `pfmap`.
+- `pvoid` can now replace every location with any `PBoring`, not just `PUnit`.
+- `PTraversable` now has a `ptraverse_` method, which allows us to avoid
+  rebuilding the `PTraversable` if we don't need it anymore. This allows much
+  better folding, for example.
+- `PSemiTraversable` now has a `psemitraverse_` method, with similar benefits to
+  `ptraverse_`.
+- `psemifold`, `psemifoldMap` and `psemifoldComonad` gained a `PSubcategory t a` 
+  constraint, as the 'container' is guaranteed non-empty in such a case.
+- Significant performance improvements for `PTraversable` and `PSemiTraversable`
+  instances.
+
 ## 1.1.0 -- 2022-06-17
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            1.1.0
+version:            1.2.0
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra
@@ -73,6 +73,7 @@ library
     Plutarch.Api.V1.Value.Unsorted
     Plutarch.Extra.Applicative
     Plutarch.Extra.Bool
+    Plutarch.Extra.Boring
     Plutarch.Extra.Category
     Plutarch.Extra.Comonad
     Plutarch.Extra.Const

--- a/src/Plutarch/Extra/Boring.hs
+++ b/src/Plutarch/Extra/Boring.hs
@@ -1,0 +1,48 @@
+-- Needed to ensure mapBoring is used properly
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+module Plutarch.Extra.Boring (
+    -- * Type class
+    PBoring (..),
+
+    -- * Functions
+    mapBoring,
+) where
+
+import Data.Kind (Type)
+import Plutarch (
+    S,
+    Term,
+    pcon,
+    phoistAcyclic,
+    plam,
+    type (:-->),
+ )
+import Plutarch.Unit (PUnit (PUnit))
+
+{- | Represents singleton values. They are \'boring\' as having a value of that
+ type tells you absolutely nothing, as they're all the same.
+
+ = Laws
+
+ * /Singleton/: @x = boring@
+
+ @since 1.2.0
+-}
+class PBoring (a :: S -> Type) where
+    pboring :: Term s a
+
+-- | @since 1.2.0
+instance PBoring PUnit where
+    pboring = pcon PUnit
+
+{- | As every 'PBoring' instance is a singleton, we can always convert one
+ boring value into another.
+
+ @since 1.2.0
+-}
+mapBoring ::
+    forall (a :: S -> Type) (b :: S -> Type) (s :: S).
+    (PBoring a, PBoring b) =>
+    Term s (a :--> b)
+mapBoring = phoistAcyclic $ plam $ const pboring

--- a/src/Plutarch/Extra/Identity.hs
+++ b/src/Plutarch/Extra/Identity.hs
@@ -24,6 +24,7 @@ import Plutarch (
 import Plutarch.Bool (PEq, POrd)
 import Plutarch.Builtin (PIsData)
 import Plutarch.Extra.Applicative (PApplicative (ppure), PApply (pliftA2))
+import Plutarch.Extra.Boring (PBoring (pboring))
 import Plutarch.Extra.Comonad (
     PComonad (pextract),
     PExtend (pextend),
@@ -120,3 +121,7 @@ instance PApply PIdentity where
 -- | @since 1.0.0
 instance PApplicative PIdentity where
     ppure = phoistAcyclic $ plam $ pcon . PIdentity
+
+-- | @since 1.2.0
+instance (PBoring a) => PBoring (PIdentity a) where
+    pboring = ppure # pboring

--- a/src/Plutarch/Extra/Sum.hs
+++ b/src/Plutarch/Extra/Sum.hs
@@ -25,6 +25,7 @@ import Plutarch (
 import Plutarch.Bool (PEq, POrd)
 import Plutarch.Builtin (PIsData)
 import Plutarch.Extra.Applicative (PApplicative (ppure), PApply (pliftA2))
+import Plutarch.Extra.Boring (PBoring (pboring))
 import Plutarch.Extra.Comonad (PComonad (pextract), PExtend (pextend))
 import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap))
 import Plutarch.Extra.TermCont (pmatchC)
@@ -123,3 +124,7 @@ instance PApply PSum where
 -- | @since 1.0.0
 instance PApplicative PSum where
     ppure = phoistAcyclic $ plam $ pcon . PSum
+
+-- | @since 1.2.0
+instance (PBoring a) => PBoring (PSum a) where
+    pboring = ppure # pboring

--- a/src/Plutarch/Extra/Tagged.hs
+++ b/src/Plutarch/Extra/Tagged.hs
@@ -31,6 +31,7 @@ import Plutarch (
 import Plutarch.Bool (PEq, POrd)
 import Plutarch.Builtin (PAsData, PData, PIsData)
 import Plutarch.Extra.Applicative (PApplicative (ppure), PApply (pliftA2))
+import Plutarch.Extra.Boring (PBoring (pboring))
 import Plutarch.Extra.Comonad (
     PComonad (pextract),
     PExtend (pextend),
@@ -254,3 +255,7 @@ deriving newtype instance
 deriving newtype instance
     (PlutusTx.UnsafeFromData underlying) =>
     PlutusTx.UnsafeFromData (Tagged tag underlying)
+
+-- | @since 1.2.0
+instance (PBoring underlying) => PBoring (Tagged tag underlying) where
+    pboring = ppure # pboring

--- a/src/Plutarch/Extra/Traversable.hs
+++ b/src/Plutarch/Extra/Traversable.hs
@@ -39,9 +39,14 @@ import Plutarch.Api.V1.Maybe (PMaybeData (PDJust, PDNothing))
 import Plutarch.Builtin (PBuiltinList, pdata, pfromData)
 import Plutarch.DataRepr (pdcons, pdnil, pfield)
 import Plutarch.Either (PEither (PLeft, PRight))
-import Plutarch.Extra.Applicative (PApplicative (ppure), PApply (pliftA2))
+import Plutarch.Extra.Applicative (
+    PApplicative (ppure),
+    PApply (pliftA2),
+    (#*>),
+ )
+import Plutarch.Extra.Boring (PBoring (pboring))
 import Plutarch.Extra.Comonad (PComonad (pextract))
-import Plutarch.Extra.Const (PConst (PConst))
+import Plutarch.Extra.Const (PConst (PConst), preconst)
 import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap))
 import Plutarch.Extra.Identity (PIdentity (PIdentity))
 import Plutarch.Extra.Sum (PSum (PSum))
@@ -50,6 +55,7 @@ import Plutarch.Integer (PInteger)
 import Plutarch.List (PList, pcons, pnil, puncons)
 import Plutarch.Maybe (PMaybe (PJust, PNothing))
 import Plutarch.Pair (PPair (PPair))
+import Plutarch.Unit (PUnit)
 
 -- | @since 1.0.0
 class (PFunctor t) => PTraversable (t :: (S -> Type) -> S -> Type) where
@@ -64,56 +70,120 @@ class (PFunctor t) => PTraversable (t :: (S -> Type) -> S -> Type) where
         ) =>
         Term s ((a :--> f b) :--> t a :--> f (t b))
 
+    -- | This avoids re-building the input 'PTraversable' if we end up throwing
+    -- it away anyway. In the case where we only care about the effect, and
+    -- don't need the 'PTraversable' afterwards, this can be more efficient.
+    --
+    -- = Note
+    --
+    -- This is \'boredom-polymorphic\' to ensure that we don't run into issues
+    -- with 'PSubcategory' constraints. This is why we choose the order of type
+    -- variables as we do: it allows you to easily choose which 'PBoring' thing
+    -- you want.
+    --
+    -- @since 1.2.0
+    ptraverse_ ::
+        forall
+            (b :: S -> Type)
+            (f :: (S -> Type) -> S -> Type)
+            (a :: S -> Type)
+            (s :: S).
+        ( PApplicative f
+        , PSubcategory f b
+        , PBoring b
+        , PSubcategory t a
+        ) =>
+        Term s ((a :--> f b) :--> t a :--> f b)
+
 -- | @since 1.0.0
 instance PTraversable PIdentity where
     ptraverse = psemitraverse
+    ptraverse_ = psemitraverse_
 
 -- | @since 1.0.0
 instance PTraversable PSum where
     ptraverse = psemitraverse
+    ptraverse_ = psemitraverse_
 
 -- | @since 1.0.0
 instance PTraversable (PConst a) where
     ptraverse = phoistAcyclic $
-        plam $ \_ t -> unTermCont $ do
-            PConst tx <- pmatchC t
-            pure $ ppure # (pcon . PConst $ tx)
+        plam $ \_ t ->
+            ppure # preconst t
+    ptraverse_ = phoistAcyclic $
+        plam $ \_ _ ->
+            ppure # pboring
 
 -- | @since 1.0.0
 instance PTraversable PMaybe where
     ptraverse = phoistAcyclic $
         plam $ \f t -> unTermCont $ do
             t' <- pmatchC t
-            case t' of
-                PNothing -> pure $ ppure # pcon PNothing
-                PJust x -> do
-                    res <- pletC (f # x)
-                    pure $ pfmap # plam (pcon . PJust) # res
+            pure $ case t' of
+                PNothing -> ppure # pcon PNothing
+                PJust x -> pfmap # plam (pcon . PJust) # (f # x)
+    ptraverse_ = phoistAcyclic $
+        plam $ \f t -> unTermCont $ do
+            t' <- pmatchC t
+            pure $ case t' of
+                PNothing -> ppure # pboring
+                PJust x -> f # x
 
 -- | @since 1.0.0
 instance PTraversable PMaybeData where
     ptraverse = phoistAcyclic $
         plam $ \f t -> unTermCont $ do
             t' <- pmatchC t
-            case t' of
-                PDNothing _ -> pure $ ppure # (pcon . PDNothing $ pdnil)
-                PDJust t'' -> do
-                    x <- pletC (pfromData $ pfield @"_0" # t'')
-                    res <- pletC (f # x)
-                    pure $ pfmap # plam (\y -> pcon . PDJust $ pdcons # pdata y # pdnil) # res
+            pure $ case t' of
+                PDNothing _ -> ppure # (pcon . PDNothing $ pdnil)
+                PDJust t'' ->
+                    let res = f # pfromData (pfield @"_0" # t'')
+                     in pfmap # plam (\y -> pcon . PDJust $ pdcons # pdata y # pdnil) # res
+    ptraverse_ = phoistAcyclic $
+        plam $ \f t -> unTermCont $ do
+            t' <- pmatchC t
+            pure $ case t' of
+                PDNothing _ -> ppure # pboring
+                PDJust t'' -> f # pfromData (pfield @"_0" # t'')
 
 -- | @since 1.0.0
 instance PTraversable PList where
     ptraverse = phoistAcyclic $
         pfix
             #$ plam
-            $ \r f xs ->
+            $ \self f xs ->
                 pmatch (puncons # xs) $ \case
                     PNothing -> ppure # pnil
                     PJust t' -> do
                         pmatch t' $ \case
                             PPair thead ttail ->
-                                pliftA2 # pcons # (f # thead) # (r # f # ttail)
+                                pliftA2 # pcons # (f # thead) # (self # f # ttail)
+    ptraverse_ ::
+        forall
+            (b :: S -> Type)
+            (f :: (S -> Type) -> S -> Type)
+            (a :: S -> Type)
+            (s :: S).
+        ( PApplicative f
+        , PSubcategory f b
+        , PBoring b
+        ) =>
+        Term s ((a :--> f b) :--> PList a :--> f b)
+    ptraverse_ = phoistAcyclic $ pfix #$ plam $ go
+      where
+        go ::
+            forall (s' :: S).
+            Term s' ((a :--> f b) :--> PList a :--> f b) ->
+            Term s' (a :--> f b) ->
+            Term s' (PList a) ->
+            Term s' (f b)
+        go self f xs = unTermCont $ do
+            t <- pmatchC (puncons # xs)
+            case t of
+                PNothing -> pure $ ppure # pboring
+                PJust t' -> do
+                    PPair thead ttail <- pmatchC t'
+                    pure $ (f # thead) #*> (self # f # ttail)
 
 -- | @since 1.0.0
 instance PTraversable PBuiltinList where
@@ -127,21 +197,53 @@ instance PTraversable PBuiltinList where
                         pmatch t' $ \case
                             PPair thead ttail ->
                                 pliftA2 # pcons # (f # thead) # (r # f # ttail)
+    ptraverse_ ::
+        forall
+            (b :: S -> Type)
+            (f :: (S -> Type) -> S -> Type)
+            (a :: S -> Type)
+            (s :: S).
+        ( PApplicative f
+        , PSubcategory f b
+        , PBoring b
+        , PSubcategory PBuiltinList a
+        ) =>
+        Term s ((a :--> f b) :--> PBuiltinList a :--> f b)
+    ptraverse_ = phoistAcyclic $ pfix #$ plam $ go
+      where
+        go ::
+            forall (s' :: S).
+            Term s' ((a :--> f b) :--> PBuiltinList a :--> f b) ->
+            Term s' (a :--> f b) ->
+            Term s' (PBuiltinList a) ->
+            Term s' (f b)
+        go self f xs = unTermCont $ do
+            t <- pmatchC (puncons # xs)
+            case t of
+                PNothing -> pure $ ppure # pboring
+                PJust t' -> do
+                    PPair thead ttail <- pmatchC t'
+                    pure $ (f # thead) #*> (self # f # ttail)
 
 -- | @since 1.0.0
 instance PTraversable (PPair a) where
     ptraverse = psemitraverse
+    ptraverse_ = psemitraverse_
 
 -- | @since 1.0.0
 instance PTraversable (PEither e) where
     ptraverse = phoistAcyclic $
         plam $ \f t -> unTermCont $ do
             t' <- pmatchC t
-            case t' of
-                PLeft e -> pure $ ppure # (pcon . PLeft $ e)
-                PRight x -> do
-                    res <- pletC (f # x)
-                    pure $ pfmap # plam (pcon . PRight) # res
+            pure $ case t' of
+                PLeft e -> ppure # (pcon . PLeft $ e)
+                PRight x -> pfmap # plam (pcon . PRight) # (f # x)
+    ptraverse_ = phoistAcyclic $
+        plam $ \f t -> unTermCont $ do
+            t' <- pmatchC t
+            pure $ case t' of
+                PLeft _ -> ppure # pboring
+                PRight x -> f # x
 
 -- | @since 1.0.0
 class (PTraversable t) => PSemiTraversable (t :: (S -> Type) -> S -> Type) where
@@ -154,12 +256,29 @@ class (PTraversable t) => PSemiTraversable (t :: (S -> Type) -> S -> Type) where
         ) =>
         Term s ((a :--> f b) :--> t a :--> f (t b))
 
+    -- Similar to 'ptraverse_', but only requiring an 'Apply'.
+    --
+    -- @since 1.2.0
+    psemitraverse_ ::
+        forall
+            (b :: S -> Type)
+            (f :: (S -> Type) -> S -> Type)
+            (a :: S -> Type)
+            (s :: S).
+        ( PApply f
+        , PSubcategory f b
+        , PBoring b
+        , PSubcategory t a
+        ) =>
+        Term s ((a :--> f b) :--> t a :--> f b)
+
 -- | @since 1.0.0
 instance PSemiTraversable PIdentity where
     psemitraverse = phoistAcyclic $
         plam $ \f t -> unTermCont $ do
             PIdentity tx <- pmatchC t
             pure $ pfmap # ppure # (f # tx)
+    psemitraverse_ = phoistAcyclic $ plam $ \f t -> f # (pextract # t)
 
 -- | @since 1.0.0
 instance PSemiTraversable PSum where
@@ -167,6 +286,7 @@ instance PSemiTraversable PSum where
         plam $ \f t -> unTermCont $ do
             PSum tx <- pmatchC t
             pure $ pfmap # ppure # (f # tx)
+    psemitraverse_ = phoistAcyclic $ plam $ \f t -> f # (pextract # t)
 
 -- | @since 1.0.0
 instance PSemiTraversable (PPair a) where
@@ -175,47 +295,55 @@ instance PSemiTraversable (PPair a) where
             PPair x y <- pmatchC t
             res <- pletC (f # y)
             pure $ pfmap # plam (pcon . PPair x) # res
+    psemitraverse_ = phoistAcyclic $
+        plam $ \f t -> unTermCont $ do
+            PPair _ ty <- pmatchC t
+            pure $ f # ty
 
 {- | Collapse a non-empty \'structure\' full of a 'Semigroup'.
 
- @since 1.0.0
+ @since 1.2.0
 -}
 psemifold ::
-    forall (t :: (S -> Type) -> S -> Type) (a :: S -> Type) (s :: S).
-    (PSemiTraversable t, forall (s' :: S). Semigroup (Term s' a)) =>
+    forall
+        (t :: (S -> Type) -> S -> Type)
+        (a :: S -> Type)
+        (s :: S).
+    ( PSemiTraversable t
+    , forall (s' :: S). Semigroup (Term s' a)
+    , PSubcategory t a
+    ) =>
     Term s (t a :--> a)
 psemifold = phoistAcyclic $
     plam $ \t -> unTermCont $ do
-        PConst res <- pmatchC (psemitraverse # go # t)
+        PConst res <- pmatchC (psemitraverse_ # go # t)
         pure res
   where
-    go ::
-        forall (s' :: S).
-        Term s' (a :--> PConst a a)
+    go :: forall (s' :: S). Term s' (a :--> PConst a PUnit)
     go = phoistAcyclic $ plam $ pcon . PConst
 
 {- | Collapse a non-empty \'structure\' with a projection into a 'Semigroup'.
 
- @since 1.0.0
+ @since 1.2.0
 -}
 psemifoldMap ::
     forall (t :: (S -> Type) -> S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
-    (PSemiTraversable t, forall (s' :: S). Semigroup (Term s' b)) =>
+    (PSemiTraversable t, forall (s' :: S). Semigroup (Term s' b), PSubcategory t a) =>
     Term s ((a :--> b) :--> t a :--> b)
 psemifoldMap = phoistAcyclic $
     plam $ \f t -> unTermCont $ do
-        PConst res <- pmatchC (psemitraverse # (go # f) # t)
+        PConst res <- pmatchC (psemitraverse_ # (go # f) # t)
         pure res
   where
     go ::
         forall (s' :: S).
-        Term s' ((a :--> b) :--> a :--> PConst b a)
+        Term s' ((a :--> b) :--> a :--> PConst b PUnit)
     go = phoistAcyclic $ plam $ \f x -> pcon . PConst $ f # x
 
 {- | Collapse a non-empty \'structure\' with a projection into a 'PComonad'.
  This is the most general semifold possible.
 
- @since 1.0.0
+ @since 1.2.0
 -}
 psemifoldComonad ::
     forall
@@ -228,6 +356,7 @@ psemifoldComonad ::
     , PSemiTraversable t
     , forall (s' :: S). Semigroup (Term s' (f b))
     , PSubcategory f b
+    , PSubcategory t a
     ) =>
     Term s ((a :--> f b) :--> t a :--> b)
 psemifoldComonad = phoistAcyclic $ plam $ \f t -> pextract # (psemifoldMap # f # t)
@@ -245,12 +374,12 @@ pfold ::
     Term s (t a :--> a)
 pfold = phoistAcyclic $
     plam $ \t -> unTermCont $ do
-        PConst res <- pmatchC (ptraverse # go # t)
+        PConst res <- pmatchC (ptraverse_ # go # t)
         pure res
   where
     go ::
         forall (s' :: S).
-        Term s' (a :--> PConst a a)
+        Term s' (a :--> PConst a PUnit)
     go = phoistAcyclic $ plam $ pcon . PConst
 
 {- | Collapse a possibly empty \'structure\' with a projection into a 'Monoid'.
@@ -266,12 +395,12 @@ pfoldMap ::
     Term s ((a :--> b) :--> t a :--> b)
 pfoldMap = phoistAcyclic $
     plam $ \f t -> unTermCont $ do
-        PConst res <- pmatchC (ptraverse # (go # f) # t)
+        PConst res <- pmatchC (ptraverse_ # (go # f) # t)
         pure res
   where
     go ::
         forall (s' :: S).
-        Term s' ((a :--> b) :--> a :--> PConst b a)
+        Term s' ((a :--> b) :--> a :--> PConst b PUnit)
     go = phoistAcyclic $ plam $ \f x -> pcon . PConst $ f # x
 
 {- | Collapse a possibly empty \'structure\' with a projection into a

--- a/src/Plutarch/Extra/Traversable.hs
+++ b/src/Plutarch/Extra/Traversable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -69,6 +70,8 @@ class (PFunctor t) => PTraversable (t :: (S -> Type) -> S -> Type) where
         , PSubcategory t b
         ) =>
         Term s ((a :--> f b) :--> t a :--> f (t b))
+    default ptraverse :: _
+    ptraverse = psemitraverse_
 
     -- | This avoids re-building the input 'PTraversable' if we end up throwing
     -- it away anyway. In the case where we only care about the effect, and


### PR DESCRIPTION
The specifics are detailed in the changelog. This improves performance (potentially significantly) when `PTraversable` and `PSemiTraversable` are used for fold-like behaviours only. We also introduce some additional flexibility for 'placeholder' types via `PBoring`.