### PR TITLE
Explicit control over evaluated terms

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2943,16 +2943,16 @@
         "secp256k1-haskell": "secp256k1-haskell"
       },
       "locked": {
-        "lastModified": 1659381657,
-        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "lastModified": 1660245357,
+        "narHash": "sha256-Q93Lq6leerCQedmN+3lJQWotyuGAhW6Sn14EKZd2SsA=",
         "owner": "Plutonomicon",
         "repo": "plutarch-plutus",
-        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
+        "rev": "3fe25c2376bca1a563ceecc273ae31771264e089",
         "type": "github"
       },
       "original": {
         "owner": "Plutonomicon",
-        "ref": "staging",
+        "ref": "master",
         "repo": "plutarch-plutus",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
 
     # Plutarch and its friends
     plutarch = {
-      url = "github:Plutonomicon/plutarch-plutus?ref=staging";
+      url = "github:Plutonomicon/plutarch-plutus?ref=master";
 
       inputs.emanote.follows =
         "plutarch/haskell-nix/nixpkgs-unstable";

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -100,6 +100,7 @@ library
     Plutarch.Extra.TermCont
     Plutarch.Extra.These
     Plutarch.Extra.Traversable
+    Plutarch.Extra.Evaluated
     Plutarch.Orphans
 
   build-depends:
@@ -108,6 +109,7 @@ library
     , generics-sop
     , plutarch-extra
     , plutarch-numeric
+    , plutus-core
     , tagged
     , text
 

--- a/src/Plutarch/Extra/Evaluated.hs
+++ b/src/Plutarch/Extra/Evaluated.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE GADTs #-}
+{-# OPTIONS_GHC -Wno-all #-}
+
+module Plutarch.Extra.Evaluated (
+    EvaluatedTerm(..),
+    (!#),
+    (!#$),
+    (##),
+    (##$),
+    pelift,
+    peconstant,
+) where
+
+import Data.Text (Text)
+import Plutarch.Lift
+import Plutarch.Prelude
+import Plutarch.Internal
+import Plutarch.Evaluate
+import PlutusCore.Evaluation.Machine.ExBudget (ExBudget)
+import Data.Default (def)
+import Data.Type.Bool
+
+data EvaluatedTerm (evaluated :: Bool) (p :: S -> Type)
+    = EvaluatedTerm (forall s. Term s p)
+
+evaluateTerm' ::
+    Config ->
+    EvaluatedTerm e p ->
+    Either Text (Either EvalError (EvaluatedTerm 'True p), ExBudget, [Text])
+evaluateTerm' config (EvaluatedTerm t) =
+    go <$> evalTerm config t
+    where
+      go :: (Either EvalError (ClosedTerm p),a, b) ->
+            (Either EvalError (EvaluatedTerm 'True p),a,b)
+      go (x, y, z) = (EvaluatedTerm <$> x, y, z)
+    
+evaluateTerm :: EvaluatedTerm e p -> EvaluatedTerm 'True p
+evaluateTerm (EvaluatedTerm t) =
+    case evalTerm def t of
+        Left err -> error $ show err
+        Right (Right x, _, _) -> EvaluatedTerm x
+        Right (Left err, _, _) -> error $ show err
+
+eapp ::
+    forall (e :: Bool) (f :: Bool) (p :: S -> Type) (q :: S -> Type).
+    EvaluatedTerm e (p :--> q) ->
+    EvaluatedTerm f p ->
+    EvaluatedTerm 'False q
+eapp (EvaluatedTerm f) (EvaluatedTerm x) = EvaluatedTerm $ f # x
+
+eapp' ::
+    forall (e :: Bool) (p :: S -> Type) (q :: S -> Type).
+    ClosedTerm (p :--> q) ->
+    EvaluatedTerm e p ->
+    EvaluatedTerm 'False q
+eapp' f (EvaluatedTerm x) = EvaluatedTerm $ f # x
+
+(!#) ::
+    forall (e :: Bool) (f :: Bool) (p :: S -> Type) (q :: S -> Type).    
+    EvaluatedTerm e (p :--> q) ->
+    EvaluatedTerm f p ->
+    EvaluatedTerm 'False q
+(!#) = eapp
+
+infixl 8 !#
+
+(!#$) ::
+    forall (e :: Bool) (f :: Bool) (p :: S -> Type) (q :: S -> Type).    
+    EvaluatedTerm e (p :--> q) ->
+    EvaluatedTerm f p ->
+    EvaluatedTerm 'False q
+(!#$) = eapp
+
+infixr 0 !#$
+
+(##) ::
+    forall (e :: Bool) (f :: Bool) (p :: S -> Type) (q :: S -> Type).    
+    ClosedTerm (p :--> q) ->
+    EvaluatedTerm f p ->
+    EvaluatedTerm 'False q
+(##) = eapp'
+
+infixl 8 ##
+
+(##$) ::
+    forall (e :: Bool) (f :: Bool) (p :: S -> Type) (q :: S -> Type).    
+    ClosedTerm (p :--> q) ->
+    EvaluatedTerm f p ->
+    EvaluatedTerm 'False q
+(##$) = eapp'
+
+infixr 0 ##$    
+
+pelift ::
+    forall (e :: Bool) (p :: S -> Type).
+    PLift p =>
+    EvaluatedTerm e p ->
+    PLifted p
+pelift (EvaluatedTerm x) = plift x
+
+peconstant ::
+    forall (e :: Bool) (p :: S -> Type).    
+    PLift p =>
+    PLifted p ->
+    EvaluatedTerm 'True p
+peconstant x = EvaluatedTerm $ pconstant x    


### PR DESCRIPTION
I think this can replace `CompiledTerm a` with `EvaluatedTerm 'False a`. 

Any name suggestion to replace `EvaluatedTerm` would be very helpful. (I don't like it's current name).

I will add docstrings once this is a usable idea.