### PR TITLE
Define Plut, replace uses of Top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 * `since`s added to `Plutarch.Extra.Record` functions.
 * `(.=)` no longer requires an `SListI` constraint.
+* `DeriveGeneric`, `DeriveAnyClass` and `TypeFamilies` are on by default.
 
 ## 3.0.2 -- 2022-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.1.0 -- 2022-08-17
+
+### Added
+
+* `Plut` as a replacement for `Top`. This is specialized for kind `S -> Type`.
+
+### Removed
+
+* Uses of `generics-sop` in every module except `Plutarch.Extra.IsData`.
+
+### Changed
+
+* `since`s added to `Plutarch.Extra.Record` functions.
+* `(.=)` no longer requires an `SListI` constraint.
+
 ## 3.0.1 -- 2022-08-15
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.0.1
+version:            3.1.0
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra
@@ -41,6 +41,8 @@ common common-lang
     BinaryLiterals
     ConstraintKinds
     DataKinds
+    DeriveAnyClass
+    DeriveGeneric
     DeriveTraversable
     DerivingVia
     EmptyCase

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -61,10 +61,10 @@ common common-lang
     MultiParamTypeClasses
     NumericUnderscores
     OverloadedStrings
-    PackageImports
     ScopedTypeVariables
     StandaloneDeriving
     TupleSections
+    TypeFamilies
     TypeOperators
 
   default-language:   Haskell2010

--- a/src/Plutarch/Extra/Applicative.hs
+++ b/src/Plutarch/Extra/Applicative.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.Applicative (

--- a/src/Plutarch/Extra/AssetClass.hs
+++ b/src/Plutarch/Extra/AssetClass.hs
@@ -12,8 +12,7 @@ module Plutarch.Extra.AssetClass (
 ) where
 
 import Data.Kind (Type)
-import qualified GHC.Generics as GHC
-import Generics.SOP (Generic)
+import GHC.Generics (Generic)
 import Plutarch (
     DerivePlutusType (..),
     PlutusType,
@@ -72,10 +71,6 @@ newtype PAssetClass (s :: S)
             )
         )
     deriving stock
-        ( -- | @since 0.1.0
-          GHC.Generic
-        )
-    deriving anyclass
         ( -- | @since 0.1.0
           Generic
         )

--- a/src/Plutarch/Extra/AssetClass.hs
+++ b/src/Plutarch/Extra/AssetClass.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.AssetClass (

--- a/src/Plutarch/Extra/Const.hs
+++ b/src/Plutarch/Extra/Const.hs
@@ -15,8 +15,6 @@ module Plutarch.Extra.Const (
 
 import Data.Kind (Type)
 import GHC.Generics (Generic)
-import Generics.SOP (Top)
-import qualified Generics.SOP as SOP
 import Plutarch (
     DerivePlutusType (..),
     PlutusType,
@@ -36,6 +34,7 @@ import Plutarch.Extra.Boring (PBoring (pboring))
 import Plutarch.Extra.Functor (
     PBifunctor (PSubcategoryLeft, PSubcategoryRight, pbimap, psecond),
     PFunctor (PSubcategory, pfmap),
+    Plut,
  )
 import Plutarch.Extra.TermCont (pmatchC)
 import Plutarch.Integer (PIntegral)
@@ -55,8 +54,6 @@ newtype PConst (a :: S -> Type) (b :: S -> Type) (s :: S)
         )
     deriving anyclass
         ( -- | @since 1.0.0
-          SOP.Generic
-        , -- | @since 1.0.0
           PlutusType
         )
 
@@ -85,15 +82,15 @@ deriving anyclass instance (PNum a) => PNum (PConst a b)
 -- | @since 1.0.0
 deriving anyclass instance (PShow a) => PShow (PConst a b)
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor (PConst a) where
-    type PSubcategory (PConst a) = Top
+    type PSubcategory (PConst a) = Plut
     pfmap = psecond
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PBifunctor PConst where
-    type PSubcategoryLeft PConst = Top
-    type PSubcategoryRight PConst = Top
+    type PSubcategoryLeft PConst = Plut
+    type PSubcategoryRight PConst = Plut
     pbimap = phoistAcyclic $
         plam $ \f _ t -> unTermCont $ do
             PConst tx <- pmatchC t

--- a/src/Plutarch/Extra/Const.hs
+++ b/src/Plutarch/Extra/Const.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/src/Plutarch/Extra/DebuggableScript.hs
+++ b/src/Plutarch/Extra/DebuggableScript.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE RankNTypes #-}

--- a/src/Plutarch/Extra/Field.hs
+++ b/src/Plutarch/Extra/Field.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Plutarch.Extra.Field (pletAll, pletAllC) where
 

--- a/src/Plutarch/Extra/FixedDecimal.hs
+++ b/src/Plutarch/Extra/FixedDecimal.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 

--- a/src/Plutarch/Extra/FixedDecimal.hs
+++ b/src/Plutarch/Extra/FixedDecimal.hs
@@ -20,7 +20,6 @@ import Data.Bifunctor (first)
 import Data.Proxy (Proxy (Proxy))
 import GHC.Generics (Generic)
 import GHC.TypeLits (KnownNat, Nat, natVal)
-import qualified Generics.SOP as SOP
 import Plutarch.Api.V1 (PValue)
 import Plutarch.Api.V2 (AmountGuarantees, KeyGuarantees)
 import Plutarch.Bool (PEq, POrd, PPartialOrd)
@@ -68,8 +67,6 @@ newtype PFixedDecimal (unit :: Nat) (s :: S)
         )
     deriving anyclass
         ( -- | @since 1.0.0
-          SOP.Generic
-        , -- | @since 1.0.0
           PlutusType
         , -- | @since 1.0.0
           PIsData

--- a/src/Plutarch/Extra/Functor.hs
+++ b/src/Plutarch/Extra/Functor.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Plutarch.Extra.Functor (
     -- * Type classes

--- a/src/Plutarch/Extra/Functor.hs
+++ b/src/Plutarch/Extra/Functor.hs
@@ -3,6 +3,7 @@
 
 module Plutarch.Extra.Functor (
     -- * Type classes
+    Plut,
     PFunctor (..),
     PBifunctor (..),
 
@@ -15,7 +16,6 @@ module Plutarch.Extra.Functor (
 ) where
 
 import Data.Kind (Constraint, Type)
-import Generics.SOP (Top)
 import Plutarch (
     S,
     Term,
@@ -49,6 +49,19 @@ import Plutarch.List (PList, pmap)
 import Plutarch.Maybe (PMaybe (PJust, PNothing))
 import Plutarch.Pair (PPair (PPair))
 
+{- | Describes the entire category of Plutarch types, with arrows being Plutarch
+ functions. Since the typical name for the category of Haskell types is
+ @Hask@, we follow this trend with naming, choosing 'Plut'.
+
+ Use this for 'PSubcategory' if you want /any/ Plutarch type to be available.
+
+ @since 3.1.0
+-}
+class Plut (a :: S -> Type)
+
+-- | @since 3.1.0
+instance Plut a
+
 {- | Describes a Plutarch-level covariant endofunctor. However, unlike in
  Haskell, the endofunctor is defined over a subcategory of @Plut@, rather than
  all of it.
@@ -67,7 +80,7 @@ import Plutarch.Pair (PPair (PPair))
  * @'pfmap' '#' (f 'Plutarch.Extra.Category.#>>>' g)@ @=@ @('pfmap' '#' f)
  'Plutarch.Extra.Category.#>>>' ('pfmap' '#' g)@
 
- If @'PSubcategory' f@ is 'Top' (that is, @f@ is defined as an endofunctor on
+ If @'PSubcategory' f@ is 'Plut' (that is, @f@ is defined as an endofunctor on
  /all/ of @Plut@), the second law is a free theorem; however, in any other
  case, it may not be.
 
@@ -82,7 +95,7 @@ class PFunctor (f :: (S -> Type) -> S -> Type) where
     --
     -- Common choices for this are:
     --
-    -- * 'Top', which means \'parametric over anything of kind @'S' -> 'Type'@\'
+    -- * 'Plut', which means \'parametric over anything of kind @'S' -> 'Type'@\'
     -- * 'PIsData', which means \'parametric over things which are
     -- @Data@-encodable\'
     -- * 'PUnsafeLiftDecl', which means \'parametric over things that have a
@@ -105,9 +118,9 @@ class PFunctor (f :: (S -> Type) -> S -> Type) where
         Term s (a :--> f b :--> f a)
     pfconst = phoistAcyclic $ plam $ \x ys -> pfmap # (pconst # x) # ys
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor PMaybe where
-    type PSubcategory PMaybe = Top
+    type PSubcategory PMaybe = Plut
     pfmap = phoistAcyclic $
         plam $ \f t -> unTermCont $ do
             t' <- pmatchC t
@@ -128,9 +141,9 @@ instance PFunctor PMaybeData where
                     res <- pletC (f # x)
                     pure . pcon . PDJust $ pdcons # pdata res # pdnil
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor PList where
-    type PSubcategory PList = Top
+    type PSubcategory PList = Plut
     pfmap = phoistAcyclic $ plam $ \f t -> pmap # f # t
 
 -- | @since 1.0.0
@@ -143,14 +156,14 @@ instance forall (s :: KeyGuarantees) (k :: S -> Type). (PIsData k) => PFunctor (
     type PSubcategory (PMap s k) = PIsData
     pfmap = psecond
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor (PPair a) where
-    type PSubcategory (PPair a) = Top
+    type PSubcategory (PPair a) = Plut
     pfmap = psecond
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor (PEither e) where
-    type PSubcategory (PEither e) = Top
+    type PSubcategory (PEither e) = Plut
     pfmap = psecond
 
 {- | Infix, 'Term'-lifted version of 'pfconst'.
@@ -243,7 +256,7 @@ pvoid t = pfconst # pboring # t
 
  Furthermore, @'PSubcategoryLeft f' ~ 'PSubcategoryRight' f@ should hold; this
  may be required in the future. If both @'PSubcategoryLeft' f@ and
- @'PSubcategoryRight' f@ are 'Top', the second law is a free theorem; however,
+ @'PSubcategoryRight' f@ are 'Plut', the second law is a free theorem; however,
  this does not hold in general.
 
  If you define 'pfirst' and 'psecond', the following must also hold:
@@ -311,19 +324,19 @@ class PBifunctor (f :: (S -> Type) -> (S -> Type) -> S -> Type) where
         Term s ((b :--> d) :--> f a b :--> f a d)
     psecond = phoistAcyclic $ plam $ \g t -> pbimap # pidentity # g # t
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PBifunctor PPair where
-    type PSubcategoryLeft PPair = Top
-    type PSubcategoryRight PPair = Top
+    type PSubcategoryLeft PPair = Plut
+    type PSubcategoryRight PPair = Plut
     pbimap = phoistAcyclic $
         plam $ \f g t -> unTermCont $ do
             PPair x y <- pmatchC t
             pure . pcon . PPair (f # x) $ g # y
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PBifunctor PEither where
-    type PSubcategoryLeft PEither = Top
-    type PSubcategoryRight PEither = Top
+    type PSubcategoryLeft PEither = Plut
+    type PSubcategoryRight PEither = Plut
     pbimap = phoistAcyclic $
         plam $ \f g t -> unTermCont $ do
             t' <- pmatchC t

--- a/src/Plutarch/Extra/Identity.hs
+++ b/src/Plutarch/Extra/Identity.hs
@@ -9,8 +9,6 @@ module Plutarch.Extra.Identity (
 
 import Data.Kind (Type)
 import GHC.Generics (Generic)
-import Generics.SOP (Top)
-import qualified Generics.SOP as SOP
 import Plutarch (
     DerivePlutusType (..),
     PlutusType,
@@ -33,7 +31,7 @@ import Plutarch.Extra.Comonad (
     PComonad (pextract),
     PExtend (pextend),
  )
-import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap))
+import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap), Plut)
 import Plutarch.Extra.TermCont (pmatchC)
 import Plutarch.Integer (PIntegral)
 import Plutarch.Num (PNum)
@@ -51,8 +49,6 @@ newtype PIdentity (a :: S -> Type) (s :: S)
         )
     deriving anyclass
         ( -- | @since 1.0.0
-          SOP.Generic
-        , -- | @since 1.0.0
           PlutusType
         )
 
@@ -81,9 +77,9 @@ deriving anyclass instance (PNum a) => PNum (PIdentity a)
 -- | @since 1.0.0
 deriving anyclass instance (PShow a) => PShow (PIdentity a)
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor PIdentity where
-    type PSubcategory PIdentity = Top
+    type PSubcategory PIdentity = Plut
     pfmap = phoistAcyclic $
         plam $ \f t -> unTermCont $ do
             PIdentity t' <- pmatchC t

--- a/src/Plutarch/Extra/Identity.hs
+++ b/src/Plutarch/Extra/Identity.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.Identity (

--- a/src/Plutarch/Extra/IsData.hs
+++ b/src/Plutarch/Extra/IsData.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/src/Plutarch/Extra/List.hs
+++ b/src/Plutarch/Extra/List.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE TypeApplications #-}
 

--- a/src/Plutarch/Extra/Monoid.hs
+++ b/src/Plutarch/Extra/Monoid.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.Monoid (

--- a/src/Plutarch/Extra/Monoid.hs
+++ b/src/Plutarch/Extra/Monoid.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -13,7 +11,6 @@ module Plutarch.Extra.Monoid (
 import Control.Composition ((.*))
 import Data.Function (on)
 import GHC.Generics (Generic)
-import qualified Generics.SOP as SOP
 import Plutarch (
     DerivePlutusType (DPTStrat),
     PlutusType,
@@ -38,9 +35,7 @@ newtype PAll (s :: S) = PAll (Term s PBool)
           Generic
         )
     deriving anyclass
-        ( -- | @since 1.4.0
-          SOP.Generic
-        , -- | @since 1.3.0
+        ( -- | @since 1.3.0
           PlutusType
         , -- | @since 1.3.0
           PIsData
@@ -70,9 +65,7 @@ newtype PAny (s :: S) = PAny (Term s PBool)
           Generic
         )
     deriving anyclass
-        ( -- | @since 1.4.0
-          SOP.Generic
-        , -- | @since 1.3.0
+        ( -- | @since 1.3.0
           PlutusType
         , -- | @since 1.3.0
           PIsData

--- a/src/Plutarch/Extra/MultiSig.hs
+++ b/src/Plutarch/Extra/MultiSig.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {- |

--- a/src/Plutarch/Extra/MultiSig.hs
+++ b/src/Plutarch/Extra/MultiSig.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
@@ -20,8 +18,7 @@ module Plutarch.Extra.MultiSig (
     MultiSig (..),
 ) where
 
-import qualified GHC.Generics as GHC (Generic)
-import Generics.SOP (Generic)
+import GHC.Generics (Generic)
 import Plutarch.Api.V2 (PPubKeyHash, PTxInfo)
 import Plutarch.DataRepr (
     DerivePConstantViaData (DerivePConstantViaData),
@@ -72,15 +69,11 @@ data MultiSig = MultiSig
     }
     deriving stock
         ( -- | @since 0.1.0
-          GHC.Generic
+          Generic
         , -- | @since 0.1.0
           Eq
         , -- | @since 0.1.0
           Show
-        )
-    deriving anyclass
-        ( -- | @since 0.1.0
-          Generic
         )
 
 PlutusTx.makeLift ''MultiSig
@@ -101,10 +94,6 @@ newtype PMultiSig (s :: S) = PMultiSig
             )
     }
     deriving stock
-        ( -- | @since 0.1.0
-          GHC.Generic
-        )
-    deriving anyclass
         ( -- | @since 0.1.0
           Generic
         )

--- a/src/Plutarch/Extra/Profunctor.hs
+++ b/src/Plutarch/Extra/Profunctor.hs
@@ -5,9 +5,9 @@ module Plutarch.Extra.Profunctor (
 ) where
 
 import Data.Kind (Constraint, Type)
-import Generics.SOP (Top)
 import Plutarch (S, Term, phoistAcyclic, plam, (#), type (:-->))
 import Plutarch.Extra.Function (pidentity)
+import Plutarch.Extra.Functor (Plut)
 
 -- | @since 1.0.0
 class PProfunctor (p :: (S -> Type) -> (S -> Type) -> S -> Type) where
@@ -40,8 +40,8 @@ class PProfunctor (p :: (S -> Type) -> (S -> Type) -> S -> Type) where
         Term s ((c :--> d) :--> p a c :--> p a d)
     prmap = phoistAcyclic $ plam $ \g p -> pdimap # pidentity # g # p
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PProfunctor (:-->) where
-    type PContraSubcategory (:-->) = Top
-    type PCoSubcategory (:-->) = Top
+    type PContraSubcategory (:-->) = Plut
+    type PCoSubcategory (:-->) = Plut
     pdimap = phoistAcyclic $ plam $ \ab cd bc -> plam $ \x -> cd # (bc # (ab # x))

--- a/src/Plutarch/Extra/Profunctor.hs
+++ b/src/Plutarch/Extra/Profunctor.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
-
 module Plutarch.Extra.Profunctor (
     PProfunctor (..),
 ) where

--- a/src/Plutarch/Extra/Record.hs
+++ b/src/Plutarch/Extra/Record.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Plutarch.Extra.Record (
     mkRecord,

--- a/src/Plutarch/Extra/Star.hs
+++ b/src/Plutarch/Extra/Star.hs
@@ -13,7 +13,6 @@ module Plutarch.Extra.Star (
 
 import Data.Kind (Type)
 import GHC.Generics (Generic)
-import Generics.SOP (Top)
 import Plutarch (
     DerivePlutusType (DPTStrat),
     PlutusType,
@@ -31,7 +30,7 @@ import Plutarch (
 import Plutarch.Extra.Applicative (PApplicative (ppure), PApply (pliftA2))
 import Plutarch.Extra.Bind (PBind ((#>>=)))
 import Plutarch.Extra.Category (PCategory (pidentity), PSemigroupoid ((#>>>)))
-import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap))
+import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap), Plut)
 import Plutarch.Extra.Profunctor (PProfunctor (PCoSubcategory, PContraSubcategory, pdimap))
 import Plutarch.Extra.TermCont (pmatchC)
 
@@ -66,10 +65,10 @@ instance DerivePlutusType (PStar f a b) where
 {- | If @f@ is at least a 'PFunctor', we can pre-process and post-process work
  done in @PStar f@ using pure functions.
 
- @since 3.0.1
+ @since 3.1.0
 -}
 instance (PFunctor f) => PProfunctor (PStar f) where
-    type PContraSubcategory (PStar f) = Top
+    type PContraSubcategory (PStar f) = Plut
     type PCoSubcategory (PStar f) = PSubcategory f
     pdimap = phoistAcyclic $
         plam $ \into outOf xs -> unTermCont $ do

--- a/src/Plutarch/Extra/Star.hs
+++ b/src/Plutarch/Extra/Star.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.Star (

--- a/src/Plutarch/Extra/State.hs
+++ b/src/Plutarch/Extra/State.hs
@@ -16,8 +16,6 @@ module Plutarch.Extra.State (
 
 import Data.Kind (Type)
 import GHC.Generics (Generic)
-import Generics.SOP (Top)
-import qualified Generics.SOP as SOP
 import Plutarch (
     DerivePlutusType (..),
     PlutusType,
@@ -34,7 +32,7 @@ import Plutarch (
  )
 import Plutarch.Extra.Applicative (PApplicative (ppure), PApply (pliftA2))
 import Plutarch.Extra.Bind (PBind ((#>>=)))
-import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap))
+import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap), Plut)
 import Plutarch.Extra.TermCont (pmatchC)
 import Plutarch.Pair (PPair (PPair))
 import Plutarch.Unit (PUnit (PUnit))
@@ -47,9 +45,7 @@ newtype PState (s :: S -> Type) (a :: S -> Type) (s' :: S)
           Generic
         )
     deriving anyclass
-        ( -- | @since 1.4.0
-          SOP.Generic
-        , -- | @since 1.0.0
+        ( -- | @since 1.0.0
           PlutusType
         )
 
@@ -57,9 +53,9 @@ newtype PState (s :: S -> Type) (a :: S -> Type) (s' :: S)
 instance DerivePlutusType (PState s a) where
     type DPTStrat _ = PlutusTypeNewtype
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor (PState s) where
-    type PSubcategory (PState s) = Top
+    type PSubcategory (PState s) = Plut
     pfmap = phoistAcyclic $
         plam $ \f state -> unTermCont $ do
             PState g <- pmatchC state

--- a/src/Plutarch/Extra/State.hs
+++ b/src/Plutarch/Extra/State.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.State (

--- a/src/Plutarch/Extra/Sum.hs
+++ b/src/Plutarch/Extra/Sum.hs
@@ -10,8 +10,6 @@ module Plutarch.Extra.Sum (
 
 import Data.Kind (Type)
 import GHC.Generics (Generic)
-import Generics.SOP (Top)
-import qualified Generics.SOP as SOP
 import Plutarch (
     DerivePlutusType (..),
     PlutusType,
@@ -29,7 +27,7 @@ import Plutarch.Builtin (PIsData)
 import Plutarch.Extra.Applicative (PApplicative (ppure), PApply (pliftA2))
 import Plutarch.Extra.Boring (PBoring (pboring))
 import Plutarch.Extra.Comonad (PComonad (pextract), PExtend (pextend))
-import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap))
+import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap), Plut)
 import Plutarch.Extra.TermCont (pmatchC)
 import Plutarch.Integer (PIntegral)
 import Plutarch.Num (PNum)
@@ -47,8 +45,6 @@ newtype PSum (a :: S -> Type) (s :: S)
         )
     deriving anyclass
         ( -- | @since 1.0.0
-          SOP.Generic
-        , -- | @since 1.0.0
           PlutusType
         )
 
@@ -94,9 +90,9 @@ instance
 -- | @since 1.0.0
 deriving anyclass instance (PShow a) => PShow (PSum a)
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor PSum where
-    type PSubcategory PSum = Top
+    type PSubcategory PSum = Plut
     pfmap = phoistAcyclic $
         plam $ \f t -> unTermCont $ do
             PSum t' <- pmatchC t

--- a/src/Plutarch/Extra/Sum.hs
+++ b/src/Plutarch/Extra/Sum.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.Sum (

--- a/src/Plutarch/Extra/Tagged.hs
+++ b/src/Plutarch/Extra/Tagged.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- Needed for Tagged instances for PlutusTx stuff
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/src/Plutarch/Extra/Tagged.hs
+++ b/src/Plutarch/Extra/Tagged.hs
@@ -16,7 +16,6 @@ import Data.Bifunctor (first)
 import Data.Kind (Type)
 import Data.Tagged (Tagged (Tagged))
 import GHC.Generics (Generic)
-import Generics.SOP (Top)
 import Plutarch (
     DPTStrat,
     DerivePlutusType,
@@ -38,7 +37,7 @@ import Plutarch.Extra.Comonad (
     PComonad (pextract),
     PExtend (pextend),
  )
-import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap))
+import Plutarch.Extra.Functor (PFunctor (PSubcategory, pfmap), Plut)
 import Plutarch.Extra.TermCont (pmatchC)
 import Plutarch.Extra.Traversable (
     PSemiTraversable (psemitraverse, psemitraverse_),
@@ -126,9 +125,9 @@ deriving anyclass instance (PNum underlying) => PNum (PTagged tag underlying)
 -- -- | @since 1.0.0
 deriving anyclass instance (PShow underlying) => PShow (PTagged tag underlying)
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor (PTagged tag) where
-    type PSubcategory (PTagged tag) = Top
+    type PSubcategory (PTagged tag) = Plut
     pfmap = phoistAcyclic $
         plam $ \f t -> unTermCont $ do
             PTagged t' <- pmatchC t

--- a/src/Plutarch/Extra/TermCont.hs
+++ b/src/Plutarch/Extra/TermCont.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeApplications #-}
 

--- a/src/Plutarch/Extra/These.hs
+++ b/src/Plutarch/Extra/These.hs
@@ -19,7 +19,6 @@ module Plutarch.Extra.These (
 
 import Data.Kind (Type)
 import GHC.Generics (Generic)
-import Generics.SOP (Top)
 import Plutarch.Bool (PBool (PFalse, PTrue), PEq, POrd, PPartialOrd (..))
 import Plutarch.Builtin (PAsData, PIsData, pdata, pfromData)
 import Plutarch.DataRepr (
@@ -35,6 +34,7 @@ import Plutarch.Extra.Boring (pboring)
 import Plutarch.Extra.Functor (
     PBifunctor (PSubcategoryLeft, PSubcategoryRight, pbimap, psecond),
     PFunctor (PSubcategory, pfmap),
+    Plut,
  )
 import Plutarch.Extra.TermCont (pletC, pmatchC)
 import Plutarch.Extra.Traversable (PTraversable (ptraverse, ptraverse_))
@@ -101,15 +101,15 @@ instance (POrd a, POrd b) => PPartialOrd (PThese a b) where
 -- | @since 1.0.0
 deriving anyclass instance (PShow a, PShow b) => PShow (PThese a b)
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PFunctor (PThese a) where
-    type PSubcategory (PThese a) = Top
+    type PSubcategory (PThese a) = Plut
     pfmap = psecond
 
--- | @since 1.0.0
+-- | @since 3.1.0
 instance PBifunctor PThese where
-    type PSubcategoryLeft PThese = Top
-    type PSubcategoryRight PThese = Top
+    type PSubcategoryLeft PThese = Plut
+    type PSubcategoryRight PThese = Plut
     pbimap = phoistAcyclic $
         plam $ \f g t -> unTermCont $ do
             t' <- pmatchC t

--- a/src/Plutarch/Extra/These.hs
+++ b/src/Plutarch/Extra/These.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.These (

--- a/src/Plutarch/Extra/Value.hs
+++ b/src/Plutarch/Extra/Value.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Plutarch.Extra.Value (
     psingletonValue,

--- a/src/Plutarch/Orphans.hs
+++ b/src/Plutarch/Orphans.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 


### PR DESCRIPTION
This eliminates (most) uses of `generics-sop`. In light of this, we also vendor a version of `Top` (named `Plut`). This also allows us to generalize `.=` to not need `SListI` anymore.

One module `Plutus.Extra.IsData` still uses SOP generics in a fundamental way. As replacing this would be significant, this PR does not address this issue.

Furthermore, in light of the upstream Plutarch changes, we now globally enable `DeriveAnyClass`, `DeriveGeneric` and `TypeFamilies`; the standards document has been updated with this in mind.