### PR TITLE
Apply simple labelled optics

### DIFF
--- a/src/Plutarch/Extra/DebuggableScript.hs
+++ b/src/Plutarch/Extra/DebuggableScript.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.DebuggableScript (
   -- * Type
@@ -70,7 +71,10 @@ data DebuggableScript = DebuggableScript Script Script
 
  @since 3.8.0
 -}
-instance LabelOptic "script" A_Getter DebuggableScript DebuggableScript Script Script where
+instance
+  (k ~ A_Getter, a ~ Script, b ~ Script) =>
+  LabelOptic "script" k DebuggableScript DebuggableScript a b
+  where
   labelOptic = to $ \(DebuggableScript x _) -> x
 
 {- | Retrieves the debugging 'Script'. This is read-only, as allowing it to
@@ -78,7 +82,10 @@ instance LabelOptic "script" A_Getter DebuggableScript DebuggableScript Script S
 
  @since 3.8.0
 -}
-instance LabelOptic "debugScript" A_Getter DebuggableScript DebuggableScript Script Script where
+instance
+  (k ~ A_Getter, a ~ Script, b ~ Script) =>
+  LabelOptic "debugScript" k DebuggableScript DebuggableScript a b
+  where
   labelOptic = to $ \(DebuggableScript _ x) -> x
 
 {- | Apply a function to an argument on the compiled 'Script' level.

--- a/src/Plutarch/Extra/MultiSig.hs
+++ b/src/Plutarch/Extra/MultiSig.hs
@@ -54,7 +54,10 @@ data MultiSig = MultiSig [PubKeyHash] Integer
 
  @since 3.8.0
 -}
-instance LabelOptic "keys" A_Traversal MultiSig MultiSig PubKeyHash PubKeyHash where
+instance
+  (k ~ A_Traversal, a ~ PubKeyHash, b ~ PubKeyHash) =>
+  LabelOptic "keys" k MultiSig MultiSig a b
+  where
   labelOptic = traversalVL $
     \f (MultiSig pkhs minSigs) -> MultiSig <$> traverse f pkhs <*> pure minSigs
 
@@ -64,7 +67,10 @@ instance LabelOptic "keys" A_Traversal MultiSig MultiSig PubKeyHash PubKeyHash w
 
  @since 3.8.0
 -}
-instance LabelOptic "minSigs" A_Getter MultiSig MultiSig Integer Integer where
+instance
+  (k ~ A_Getter, a ~ Integer, b ~ Integer) =>
+  LabelOptic "minSigs" k MultiSig MultiSig a b
+  where
   labelOptic = to $ \(MultiSig _ minSigs) -> minSigs
 
 PlutusTx.makeLift ''MultiSig


### PR DESCRIPTION
Per the recent standards change, all the labelled optics have been rewritten into the inference-friendly (and newline-friendly) forms. I haven't mentioned this or bumped the version, as this is invisible from the point of view of compilation: nothing that used to compile will fail to do so, and in fact, the types are the same exactly, barring some special pleading with GHC.