### PR TITLE
Remove SOP requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.10.0 -- 2022-10-05
+
+## Removed
+
+* `Plutarch.Extra.IsData`, which is now subsumed by two other modules.
+
 ## 3.9.1 -- 2022-09-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 3.10.0 -- 2022-10-05
 
+## Added
+
+* `Plutarch.Extra.PlutusType` module:
+  * Strategy for deriving `PlutusType` via being equivalent to a `PDataRecord`.
+  * Derivation helper for `PConstantDecl` for Haskell equivalents to (wrappers
+    around) `PDataRecord`.
+* `Plutarch.Extra.Lift` module:
+  * Derivation helper for `FromData`, `ToData` and `UnsafeFromData` for Haskell
+    equivalents to (wrappers around) `PDataRecord`, provided all their fields
+    have appropriate instances.
+
+## Modified
+
+* `AssetClassData` no longer derives a SOP `Generic` instance, as it isn't
+  needed anymore.
+
 ## Removed
 
 * `Plutarch.Extra.IsData`, which is now subsumed by two other modules.

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -143,6 +143,7 @@ library
     , plutarch-numeric
     , plutus-core
     , serialise
+    , sop-core
     , tagged
     , text
 

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.9.1
+version:            3.10.0
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra
@@ -28,7 +28,6 @@ common common-lang
     -Wall -Wcompat -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Wredundant-constraints
     -Wmissing-export-lists -Wmissing-deriving-strategies -Werror
-    -Wno-partial-type-signatures
 
   mixins:
     base hiding (Prelude),
@@ -102,13 +101,13 @@ library
     Plutarch.Extra.Function
     Plutarch.Extra.Functor
     Plutarch.Extra.Identity
-    Plutarch.Extra.IsData
     Plutarch.Extra.List
     Plutarch.Extra.Map
     Plutarch.Extra.Monoid
     Plutarch.Extra.MultiSig
     Plutarch.Extra.Numeric
     Plutarch.Extra.Ord
+    Plutarch.Extra.PlutusType
     Plutarch.Extra.Precompile
     Plutarch.Extra.Profunctor
     Plutarch.Extra.Rational
@@ -133,6 +132,7 @@ library
     , containers
     , data-default
     , deepseq
+    , first-class-families
     , generics-sop
     , lens
     , optics-core

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -101,6 +101,7 @@ library
     Plutarch.Extra.Function
     Plutarch.Extra.Functor
     Plutarch.Extra.Identity
+    Plutarch.Extra.Lift
     Plutarch.Extra.List
     Plutarch.Extra.Map
     Plutarch.Extra.Monoid

--- a/src/Plutarch/Extra/AssetClass.hs
+++ b/src/Plutarch/Extra/AssetClass.hs
@@ -40,13 +40,15 @@ import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import qualified Data.Aeson as Aeson
 import Data.Tagged (Tagged, untag)
 import GHC.TypeLits (Symbol)
-import qualified Generics.SOP as SOP
 import Optics.TH (makeFieldLabelsNoPrefix)
 import Plutarch.Api.V1 (
   PCurrencySymbol,
   PTokenName,
  )
 import Plutarch.DataRepr (PDataFields)
+import Plutarch.Extra.Lift (RecordIsData (RecordIsData))
+import Plutarch.Extra.PlutusType (LiftingPDataRecord (LiftingPDataRecord))
+
 {-
 import Plutarch.Extra.IsData (
   DerivePConstantViaDataList (DerivePConstantViaDataList),
@@ -224,8 +226,6 @@ data AssetClassData = AssetClassData
       Aeson.FromJSONKey
     , -- | @since 3.9.0
       Aeson.ToJSONKey
-    , -- | @since 3.9.0
-      SOP.Generic
     )
   deriving
     ( -- | @since 3.9.0
@@ -233,14 +233,14 @@ data AssetClassData = AssetClassData
     , -- | @since 3.9.0
       PlutusTx.FromData
     )
-    via Plutarch.Extra.IsData.ProductIsData AssetClassData
+    via RecordIsData AssetClassData
   deriving
     ( -- | @since 3.9.0
       Plutarch.Lift.PConstantDecl
     )
-    via ( Plutarch.Extra.IsData.DerivePConstantViaDataList
-            AssetClassData
+    via ( LiftingPDataRecord
             PAssetClassData
+            AssetClassData
         )
 
 {- | Plutarch equivalent of 'AssetClassData'.

--- a/src/Plutarch/Extra/AssetClass.hs
+++ b/src/Plutarch/Extra/AssetClass.hs
@@ -47,10 +47,12 @@ import Plutarch.Api.V1 (
   PTokenName,
  )
 import Plutarch.DataRepr (PDataFields)
+{-
 import Plutarch.Extra.IsData (
   DerivePConstantViaDataList (DerivePConstantViaDataList),
   ProductIsData (ProductIsData),
  )
+-}
 import Plutarch.Extra.Record (mkRecordConstr, (.&), (.=))
 import Plutarch.Lift (
   PConstantDecl,

--- a/src/Plutarch/Extra/IsData.hs
+++ b/src/Plutarch/Extra/IsData.hs
@@ -29,19 +29,6 @@ import Data.Kind (Constraint)
 import Data.Maybe (fromJust)
 import Data.Proxy (Proxy (Proxy))
 import GHC.TypeLits (ErrorMessage (ShowType, Text, (:$$:), (:<>:)), TypeError)
-import Generics.SOP (
-  All,
-  IsProductType,
-  hcmap,
-  hcollapse,
-  hctraverse,
-  mapIK,
-  mapKI,
-  productTypeFrom,
-  productTypeTo,
-  unI,
- )
-import qualified Generics.SOP as SOP
 import Plutarch.Builtin (pasInt)
 import Plutarch.Extra.TermCont (pletC)
 import Plutarch.Internal.Generic (PCode, PGeneric, gpfrom, gpto)

--- a/src/Plutarch/Extra/Lift.hs
+++ b/src/Plutarch/Extra/Lift.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Plutarch.Extra.Lift (
+  -- * Derivation helpers for ToData, FromData and UnsafeFromData
+  RecordIsData (..),
+) where
+
+import Data.Functor.Identity (Identity (Identity), runIdentity)
+import Data.Proxy (Proxy (Proxy))
+import Generics.SOP (
+  All,
+  I,
+  NP,
+  NS (Z),
+  SOP (SOP),
+  hcmap,
+  hcollapse,
+  hctraverse,
+  mapIK,
+  mapKI,
+  unI,
+  unSOP,
+  unZ,
+ )
+import qualified Generics.SOP as SOP
+import Generics.SOP.GGP (GCode, GFrom, GTo, gfrom, gto)
+import PlutusTx (
+  Data (List),
+  FromData (fromBuiltinData),
+  ToData (toBuiltinData),
+  UnsafeFromData (unsafeFromBuiltinData),
+  fromData,
+  toData,
+ )
+import PlutusTx.Builtins.Internal (BuiltinData (BuiltinData))
+
+{- | Wrapper for deriving 'ToData', 'FromData' and 'UnsafeFromData'
+ consistently, using the 'List' constructor of 'Data' as the underlying
+ representation. Intended for record types, hence the name.
+
+ For safety, we recommend using 'Plutarch.Extra.PlutusType.PlutusTypeRecord'
+ as the deriving strategy for 'PlutusType' for the Plutarch equivalent of any
+ type using 'RecordIsData'; this ensures consistency, including in field
+ ordering.
+
+ For this to work, the type @a@ must:
+
+ - Implement 'Generic'; and
+ - Have fields with themselves have instances of 'ToData', 'FromData' and
+ 'UnsafeFromData', depending on what you're deriving.
+
+ If you get weird error messages, check that you meet these criteria. Also,
+ let us know, so we can have more helpful error messages!
+
+ @since 3.10.0
+-}
+newtype RecordIsData (a :: Type) = RecordIsData a
+
+-- | @since 3.10.0
+instance
+  (Generic a, GCode a ~ '[repr], All ToData repr, GFrom a) =>
+  ToData (RecordIsData a)
+  where
+  {-# INLINEABLE toBuiltinData #-}
+  toBuiltinData (RecordIsData x) =
+    BuiltinData
+      . List
+      . hcollapse
+      . hcmap (Proxy @ToData) (mapIK toData)
+      . toProduct
+      $ x
+
+-- | @since 3.10.0
+instance
+  (Generic a, GCode a ~ '[repr], All UnsafeFromData repr, GTo a) =>
+  UnsafeFromData (RecordIsData a)
+  where
+  {-# INLINEABLE unsafeFromBuiltinData #-}
+  unsafeFromBuiltinData = \case
+    BuiltinData (List xs) -> case SOP.fromList xs of
+      Nothing ->
+        error $
+          "unsafeFromBuiltinData: "
+            <> "wrong number of items for a derived RecordIsData"
+      Just prod ->
+        RecordIsData
+          . fromProduct
+          . runIdentity
+          . hctraverse (Proxy @UnsafeFromData) (unI . mapKI (Identity . unsafeFromBuiltinData . BuiltinData))
+          $ prod
+    _ ->
+      error $
+        "unsafeFromBuiltinData: "
+          <> "Derived RecordIsData expects a list, but got something else."
+
+-- | @since 3.10.0
+instance
+  (Generic a, GCode a ~ '[repr], All FromData repr, GTo a) =>
+  FromData (RecordIsData a)
+  where
+  {-# INLINEABLE fromBuiltinData #-}
+  fromBuiltinData = \case
+    BuiltinData (List xs) ->
+      RecordIsData <$> do
+        prod <- SOP.fromList xs
+        fromProduct <$> hctraverse (Proxy @FromData) (unI . mapKI fromData) prod
+    _ -> Nothing
+
+-- Helpers
+
+toProduct ::
+  forall (repr :: [Type]) (a :: Type).
+  (Generic a, GCode a ~ '[repr], GFrom a) =>
+  a ->
+  NP I repr
+toProduct = unZ . unSOP . gfrom
+
+fromProduct ::
+  forall (repr :: [Type]) (a :: Type).
+  (Generic a, GCode a ~ '[repr], GTo a) =>
+  NP I repr ->
+  a
+fromProduct = gto . SOP . Z

--- a/src/Plutarch/Extra/PlutusType.hs
+++ b/src/Plutarch/Extra/PlutusType.hs
@@ -1,61 +1,214 @@
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Plutarch.Extra.PlutusType (
-  PlutusTypeDataList
-  ) where
+  -- * Derivation strategies
+  PlutusTypeRecord,
 
-import Plutarch.DataRepr (PFields)
-import Generics.SOP.GGP (GCode)
-import GHC.TypeLits (
-  TypeError, 
-  ErrorMessage (Text, (:$$:), (:<>:), ShowType)
-  )
+  -- * Derivation helpers for PUnsafeLiftDecl and PConstantDecl
+  LiftingPDataRecord (..),
+) where
+
 import Data.Kind (Constraint)
-import Plutarch.Lift (PUnsafeLiftDecl (PLifted), PConstanted)
-import Generics.SOP (SOP (SOP), NS (Z, S),
-  NP (Nil, (:*)))
+import Data.Proxy (Proxy (Proxy))
+import Fcf (Eval, Exp, Map)
+import GHC.TypeLits (
+  ErrorMessage (ShowType, Text, (:$$:), (:<>:)),
+  TypeError,
+ )
+import Generics.SOP (
+  All,
+  I,
+  NP (Nil, (:*)),
+  NS (S, Z),
+  SOP (SOP),
+  hcmap,
+  hcollapse,
+  hctraverse,
+  mapIK,
+  mapKI,
+  unI,
+  unSOP,
+  unZ,
+ )
+import qualified Generics.SOP as SOP
 import Generics.SOP.Constraint (Head, SameShapeAs)
+import Generics.SOP.GGP (GCode, GFrom, GTo, gfrom, gto)
+import Plutarch.DataRepr (PFields)
+import Plutarch.Internal.Generic (PCode, PGeneric, gpfrom, gpto)
 import Plutarch.Internal.PlutusType (
-  PlutusTypeStrat (PlutusTypeStratConstraint,
-                   DerivedPInner,
-                   derivedPCon,
-                   derivedPMatch)
-  )
-import Plutarch.Internal.Generic (PGeneric, PCode, gpto, gpfrom)
+  PlutusTypeStrat (
+    DerivedPInner,
+    PlutusTypeStratConstraint,
+    derivedPCon,
+    derivedPMatch
+  ),
+ )
+import Plutarch.Lift (
+  PConstantDecl (
+    PConstantRepr,
+    PConstanted,
+    pconstantFromRepr,
+    pconstantToRepr
+  ),
+  PUnsafeLiftDecl (PLifted),
+ )
+import PlutusTx (Data, FromData, ToData, fromData, toData)
+
+{- | A 'PlutusType' derivation strategy designed for use with wrappers around
+ 'PDataRecord'. Similar in intent to 'PlutusTypeData', but has additional
+ checks to ensure we're actually wrapping a 'PDataRecord', as well as having a
+ Haskell equivalent.
+
+ = Using this strategy
+
+ For this strategy to work, you must ensure that the following hold:
+
+ - The type being derived over must have a Haskell equivalent, \'bridged\' by
+ means of 'PUnsafeLiftDecl'.
+ - Both the Haskell and Plutarch type must implement 'Generic'.
+ - The Haskell and Plutarch types must have the same number of fields.
+ - The Haskell and Plutarch types must have equivalent types in each position.
+
+ If you get weird errors, check that all the above hold. Also, please report
+ it to us, so we can get better error messages!
+
+ @since 3.10.0
+-}
+data PlutusTypeRecord
 
 -- | @since 3.10.0
-data PlutusTypeDataList
-
--- | @since 3.10.0
-instance PlutusTypeStrat PlutusTypeDataList where
-  type PlutusTypeStratConstraint PlutusTypeDataList = IsPlutusTypeDataList
-  type DerivedPInner PlutusTypeDataList a = GetPRecord a
-  derivedPCon x = case gpfrom x of 
+instance PlutusTypeStrat PlutusTypeRecord where
+  type PlutusTypeStratConstraint PlutusTypeRecord = IsPlutusTypeRecord
+  type DerivedPInner PlutusTypeRecord a = PDataRecord (PFields (Head (Head (PCode a))))
+  derivedPCon x = case gpfrom x of
     SOP (Z (x' :* Nil)) -> x'
-    SOP (S x') -> case x' of {} -- impossible
+    -- This is an impossible case.
+    SOP (S x') -> case x' of {}
   derivedPMatch rec f = f . gpto . SOP . Z $ rec :* Nil
+
+{- | Derivation helper for deriving 'PConstantDecl' for the Haskell equivalent
+ of a Plutus record.
+
+ Using this via-derivation ensures that we have a faithful representation
+ between the chosen Plutarch equivalent and ourselves, using similar
+ techniques to 'PlutusTypeRecord'.
+
+ To ensure this works, the following must hold:
+
+ - @a@ and @p@ must be equivalents in their respective \'worlds\', \'bridged\'
+ by means of 'PUnsafeLiftDecl'.
+ - @a@ and @p@ must both be instances of 'Generic'.
+ - @a@ and @p@ (or whatever @p@ is wrapping) must have the same number of
+ fields.
+ - @a@ and @p@ (or whatever @p@ is wrapping) must have equivalent types in
+ each position.
+
+ If you get weird errors, check that all the above hold. Also, please report
+ it to us, so we can get better error messages!
+
+ @since 3.10.0
+-}
+newtype LiftingPDataRecord (p :: S -> Type) (a :: Type)
+  = LiftingPDataRecord a
+
+-- | @since 3.10.0
+instance
+  ( IsPlutusTypeRecord p
+  , Generic a
+  , GCode a ~ '[repr]
+  , All ToData repr
+  , All FromData repr
+  , GFrom a
+  , GTo a
+  ) =>
+  PConstantDecl (LiftingPDataRecord p a)
+  where
+  type PConstantRepr (LiftingPDataRecord p a) = [Data]
+  type PConstanted (LiftingPDataRecord p a) = p
+  pconstantToRepr (LiftingPDataRecord x) =
+    hcollapse . hcmap (Proxy @ToData) (mapIK toData) . toProduct $ x
+  pconstantFromRepr dat =
+    LiftingPDataRecord <$> do
+      prod <- SOP.fromList dat
+      fromProduct <$> hctraverse (Proxy @FromData) (unI . mapKI fromData) prod
 
 -- Helpers
 
-class (
-  PGeneric p,
-  PCode p ~ '[ '[ PDataRecord (PFields (Head (Head (PCode p)))) ] ]
-  ) => IsPlutusTypeDataList p
+toProduct ::
+  forall (repr :: [Type]) (a :: Type).
+  (Generic a, GCode a ~ '[repr], GFrom a) =>
+  a ->
+  NP I repr
+toProduct = unZ . unSOP . gfrom
 
-instance (
-  PGeneric p,
-  PUnsafeLiftDecl p,
-  PCode p ~ '[ '[ PDataRecord (PFields (Head (Head (PCode p)))) ] ],
-  SameShapeAs (GetRecordTypes (GCode (PLifted p))) (PUnlabel (GetPRecord' (PCode p))),
-  MatchTypes (UD (GetRecordTypes (GCode (PLifted p)))) (PUnlabel (GetPRecord' (PCode p)))
-  ) => IsPlutusTypeDataList p
+fromProduct ::
+  forall (repr :: [Type]) (a :: Type).
+  (Generic a, GCode a ~ '[repr], GTo a) =>
+  NP I repr ->
+  a
+fromProduct = gto . SOP . Z
 
-type family GetPRecord' (a :: [[S -> Type]]) :: [PLabeledType] where
-  GetPRecord' '[ '[PDataRecord a]] = a
+-- First-class families-style helpers
 
-type family GetPRecord (a :: S -> Type) :: S -> Type where
-  GetPRecord a = PDataRecord (GetPRecord' (PCode a))
+-- Converts a type to its Plutarch equivalent
+
+data ToPlutarch :: Type -> Exp (S -> Type)
+
+type instance Eval (ToPlutarch a) = PConstanted a
+
+-- 'Pulls off' the type of a PLabeledType
+
+data Unlabel :: PLabeledType -> Exp (S -> Type)
+
+type instance Eval (Unlabel (_ ':= p)) = p
+
+-- A 'constraint summarizer', to help write a complex constraint.
+--
+-- We do this using a combination of type class and instance because
+-- PlutusTypeStratConstraint wants something of kind S -> Type -> Constraint,
+-- which we can't provide using a synonym if we want to 'name' the argument.
+
+class
+  ( -- The Plutarch type needs to be an instance of Generic
+    PGeneric p
+  , -- We need a Haskell equivalent
+    PUnsafeLiftDecl p
+  , -- We need to be a newtype around PDataRecord, or a single-constructor data
+    -- declaration whose only field is a PDataRecord
+    PCode p ~ '[ '[PDataRecord (PFields (Head (Head (PCode p))))]]
+  , -- Our Haskell and Plutarch types must have identical field counts
+    SameShapeAs
+      (Eval (Map ToPlutarch (Head (GCode (PLifted p)))))
+      (Eval (Map Unlabel (PFields (Head (Head (PCode p))))))
+  , -- Our Haskell and Plutarch types must have the same field types in the same
+    -- positions
+    MatchTypes
+      (UD (Eval (Map ToPlutarch (Head (GCode (PLifted p))))))
+      (Eval (Map Unlabel (PFields (Head (Head (PCode p))))))
+  ) =>
+  IsPlutusTypeRecord p
+
+-- Same as above, but with some rigid type variables to better convey intent. We
+-- can't do this in superclass constraints for some bizarre reason.
+instance
+  ( pfields ~ PFields (Head (Head (PCode p)))
+  , fieldTypes ~ Eval (Map ToPlutarch (Head (GCode (PLifted p))))
+  , pfieldTypes ~ Eval (Map Unlabel pfields)
+  , PGeneric p
+  , PUnsafeLiftDecl p
+  , PCode p ~ '[ '[PDataRecord pfields]]
+  , SameShapeAs fieldTypes pfieldTypes
+  , MatchTypes (UD fieldTypes) pfieldTypes
+  ) =>
+  IsPlutusTypeRecord p
+
+-- Ensures we have the same structure, with good error messages when we don't.
+
+type MatchTypes (n :: [S -> Type]) (m :: [S -> Type]) =
+  (MatchTypesError n m (MatchTypes' n m))
 
 type family MatchTypes' (n :: [S -> Type]) (m :: [S -> Type]) :: Bool where
   MatchTypes' '[] '[] = 'True
@@ -80,8 +233,13 @@ type family MatchTypesError (n :: [S -> Type]) (m :: [S -> Type]) (a :: Bool) ::
         )
     )
 
-type MatchTypes (n :: [S -> Type]) (m :: [S -> Type]) =
-  (MatchTypesError n m (MatchTypes' n m))
+-- 'Maps over' the 'stuff in' function below.
+
+type family UD (p :: [S -> Type]) :: [S -> Type] where
+  UD (x ': xs) = UD' x ': UD xs
+  UD '[] = '[]
+
+-- Recursively 'stuffs in' PAsData everywhere it can.
 
 type family UD' (p :: S -> Type) :: S -> Type where
   UD' (p x1 x2 x3 x4 x5) = p (UD' x1) (UD' x2) (UD' x3) (UD' x4) (UD' x5)
@@ -90,15 +248,3 @@ type family UD' (p :: S -> Type) :: S -> Type where
   UD' (p x1 x2) = p (UD' x1) (UD' x2)
   UD' (p x1) = p (PAsData (UD' x1))
   UD' p = p
-
-type family UD (p :: [S -> Type]) :: [S -> Type] where
-  UD (x ': xs) = UD' x ': UD xs
-  UD '[] = '[]
-
-type family GetRecordTypes (n :: [[Type]]) :: [S -> Type] where
-  GetRecordTypes '[x ': xs] = PConstanted x ': GetRecordTypes '[xs]
-  GetRecordTypes '[ '[]] = '[]
-
-type family PUnlabel (n :: [PLabeledType]) :: [S -> Type] where
-  PUnlabel ((_ ':= p) ': xs) = p ': PUnlabel xs
-  PUnlabel '[] = '[]

--- a/src/Plutarch/Extra/PlutusType.hs
+++ b/src/Plutarch/Extra/PlutusType.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE PolyKinds #-}
+
+module Plutarch.Extra.PlutusType (
+  PlutusTypeDataList
+  ) where
+
+import Plutarch.DataRepr (PFields)
+import Generics.SOP.GGP (GCode)
+import GHC.TypeLits (
+  TypeError, 
+  ErrorMessage (Text, (:$$:), (:<>:), ShowType)
+  )
+import Data.Kind (Constraint)
+import Plutarch.Lift (PUnsafeLiftDecl (PLifted), PConstanted)
+import Generics.SOP (SOP (SOP), NS (Z, S),
+  NP (Nil, (:*)))
+import Generics.SOP.Constraint (Head, SameShapeAs)
+import Plutarch.Internal.PlutusType (
+  PlutusTypeStrat (PlutusTypeStratConstraint,
+                   DerivedPInner,
+                   derivedPCon,
+                   derivedPMatch)
+  )
+import Plutarch.Internal.Generic (PGeneric, PCode, gpto, gpfrom)
+
+-- | @since 3.10.0
+data PlutusTypeDataList
+
+-- | @since 3.10.0
+instance PlutusTypeStrat PlutusTypeDataList where
+  type PlutusTypeStratConstraint PlutusTypeDataList = IsPlutusTypeDataList
+  type DerivedPInner PlutusTypeDataList a = GetPRecord a
+  derivedPCon x = case gpfrom x of 
+    SOP (Z (x' :* Nil)) -> x'
+    SOP (S x') -> case x' of {} -- impossible
+  derivedPMatch rec f = f . gpto . SOP . Z $ rec :* Nil
+
+-- Helpers
+
+class (
+  PGeneric p,
+  PCode p ~ '[ '[ PDataRecord (PFields (Head (Head (PCode p)))) ] ]
+  ) => IsPlutusTypeDataList p
+
+instance (
+  PGeneric p,
+  PUnsafeLiftDecl p,
+  PCode p ~ '[ '[ PDataRecord (PFields (Head (Head (PCode p)))) ] ],
+  SameShapeAs (GetRecordTypes (GCode (PLifted p))) (PUnlabel (GetPRecord' (PCode p))),
+  MatchTypes (UD (GetRecordTypes (GCode (PLifted p)))) (PUnlabel (GetPRecord' (PCode p)))
+  ) => IsPlutusTypeDataList p
+
+type family GetPRecord' (a :: [[S -> Type]]) :: [PLabeledType] where
+  GetPRecord' '[ '[PDataRecord a]] = a
+
+type family GetPRecord (a :: S -> Type) :: S -> Type where
+  GetPRecord a = PDataRecord (GetPRecord' (PCode a))
+
+type family MatchTypes' (n :: [S -> Type]) (m :: [S -> Type]) :: Bool where
+  MatchTypes' '[] '[] = 'True
+  MatchTypes' (x ': xs) (x ': ys) = MatchTypes' xs ys
+  MatchTypes' (x ': xs) (y ': ys) = 'False
+  MatchTypes' '[] ys = 'False
+  MatchTypes' xs '[] = 'False
+
+type family MatchTypesError (n :: [S -> Type]) (m :: [S -> Type]) (a :: Bool) :: Constraint where
+  MatchTypesError _ _ 'True = ()
+  MatchTypesError n m 'False =
+    ( 'True ~ 'False
+    , TypeError
+        ( 'Text "Error when deriving 'PlutusTypeDataList':"
+            ':$$: 'Text "\tMismatch between constituent Haskell and Plutarch types"
+            ':$$: 'Text "Constituent Haskell Types: "
+            ':$$: 'Text "\t"
+            ':<>: 'ShowType n
+            ':$$: 'Text "Constituent Plutarch Types: "
+            ':$$: 'Text "\t"
+            ':<>: 'ShowType m
+        )
+    )
+
+type MatchTypes (n :: [S -> Type]) (m :: [S -> Type]) =
+  (MatchTypesError n m (MatchTypes' n m))
+
+type family UD' (p :: S -> Type) :: S -> Type where
+  UD' (p x1 x2 x3 x4 x5) = p (UD' x1) (UD' x2) (UD' x3) (UD' x4) (UD' x5)
+  UD' (p x1 x2 x3 x4) = p (UD' x1) (UD' x2) (UD' x3) (UD' x4)
+  UD' (p x1 x2 x3) = p (UD' x1) (UD' x2) (UD' x3)
+  UD' (p x1 x2) = p (UD' x1) (UD' x2)
+  UD' (p x1) = p (PAsData (UD' x1))
+  UD' p = p
+
+type family UD (p :: [S -> Type]) :: [S -> Type] where
+  UD (x ': xs) = UD' x ': UD xs
+  UD '[] = '[]
+
+type family GetRecordTypes (n :: [[Type]]) :: [S -> Type] where
+  GetRecordTypes '[x ': xs] = PConstanted x ': GetRecordTypes '[xs]
+  GetRecordTypes '[ '[]] = '[]
+
+type family PUnlabel (n :: [PLabeledType]) :: [S -> Type] where
+  PUnlabel ((_ ':= p) ': xs) = p ': PUnlabel xs
+  PUnlabel '[] = '[]


### PR DESCRIPTION
This eliminates any need for us to ever derive SOP `Generic` again. Unfortunately, we can't be rid of that dependency in LPE itself, but now, none of our downstream consumers should need it.

Additionally, this adds significant clarifications to the original code, as well as additional compile-time safety checks. For example, `pconstantToRepr` for the 'producty' representation derivation no longer has any possibility of runtime failure, making it guaranteed total.

There's still work outstanding, and the module structure will likely change, hence the draft status.