### PR TITLE
HasLabelledGetters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.10.3 -- 2022-10-24
+
+### Added
+
+* Module `Plutarch.Extra.Optics`, containing a utility type family for working
+  with labelled-optics-driven records.
+
 ## 3.10.2 -- 2022-10-12
 
 ### Modified

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.10.2
+version:            3.10.3
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra
@@ -108,6 +108,7 @@ library
     Plutarch.Extra.Monoid
     Plutarch.Extra.MultiSig
     Plutarch.Extra.Numeric
+    Plutarch.Extra.Optics
     Plutarch.Extra.Ord
     Plutarch.Extra.Precompile
     Plutarch.Extra.Profunctor

--- a/src/Plutarch/Extra/Optics.hs
+++ b/src/Plutarch/Extra/Optics.hs
@@ -1,0 +1,30 @@
+module Plutarch.Extra.Optics (
+  HasLabelledGetters,
+) where
+
+import Data.Kind (Constraint)
+import GHC.TypeLits (Symbol)
+import Optics.Getter (A_Getter)
+import Optics.Label (LabelOptic)
+import Optics.Optic (Is)
+
+{- | Describes that a type @s@ has a collection of labelled optics, all of type
+ @k@, which is at least a getter. @labels@ describes which optics @s@ must
+ have, as name-result pairs.
+
+ = Note
+
+ This type family unfortunately has two caveats to its use:
+
+ - Redundant constraints resulting from its use won't be picked up by GHC
+   warnings.
+ - If @labels@ is empty, you will get an overlapping instances error.
+
+ Keep these in mind when using.
+
+ @since 3.10.3
+-}
+type family HasLabelledGetters (k :: Type) (s :: Type) (labels :: [(Symbol, Type)]) :: Constraint where
+  HasLabelledGetters k s '[] = (k `Is` A_Getter)
+  HasLabelledGetters k s ('(sym, t) ': labels) =
+    (LabelOptic sym k s s t t, HasLabelledGetters k s labels)


### PR DESCRIPTION
This upstreams a utility type family for working with labelled-optics-driven records from `liqwid-onchain`.