### PR TITLE
Compliance with new standards

### DIFF
--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -51,6 +51,7 @@ common common-lang
     DeriveGeneric
     DeriveTraversable
     DerivingVia
+    DuplicateRecordFields
     EmptyCase
     FlexibleContexts
     FlexibleInstances
@@ -69,6 +70,7 @@ common common-lang
     TypeApplications
     TypeFamilies
     TypeOperators
+    UndecidableInstances
     NoFieldSelectors
 
   default-language:   Haskell2010

--- a/src/Plutarch/Extra/Applicative.hs
+++ b/src/Plutarch/Extra/Applicative.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.Applicative (
   -- * Type classes

--- a/src/Plutarch/Extra/AssetClass.hs
+++ b/src/Plutarch/Extra/AssetClass.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 {- | Provides Data and Scott encoded  asset class types and utility
   functions.

--- a/src/Plutarch/Extra/Bind.hs
+++ b/src/Plutarch/Extra/Bind.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.Bind (
   -- * Type class

--- a/src/Plutarch/Extra/Const.hs
+++ b/src/Plutarch/Extra/Const.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE UndecidableInstances #-}
+-- Needed to connect PConst to Const
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Plutarch.Extra.Const (

--- a/src/Plutarch/Extra/DebuggableScript.hs
+++ b/src/Plutarch/Extra/DebuggableScript.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.DebuggableScript (
   -- * Type

--- a/src/Plutarch/Extra/FixedDecimal.hs
+++ b/src/Plutarch/Extra/FixedDecimal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Plutarch.Extra.FixedDecimal (

--- a/src/Plutarch/Extra/Identity.hs
+++ b/src/Plutarch/Extra/Identity.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-
 module Plutarch.Extra.Identity (
   PIdentity (..),
 ) where

--- a/src/Plutarch/Extra/IsData.hs
+++ b/src/Plutarch/Extra/IsData.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.IsData (
   -- * PlutusTx ToData/FromData derive-wrappers

--- a/src/Plutarch/Extra/Monoid.hs
+++ b/src/Plutarch/Extra/Monoid.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-
 module Plutarch.Extra.Monoid (
   PAll (..),
   pgetAll,

--- a/src/Plutarch/Extra/MultiSig.hs
+++ b/src/Plutarch/Extra/MultiSig.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 {- |
 Module     : Plutarch.Extra.MultiSig

--- a/src/Plutarch/Extra/Star.hs
+++ b/src/Plutarch/Extra/Star.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-
 module Plutarch.Extra.Star (
   -- * Type
   PStar (..),

--- a/src/Plutarch/Extra/State.hs
+++ b/src/Plutarch/Extra/State.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-
 module Plutarch.Extra.State (
   PState,
   pstate,

--- a/src/Plutarch/Extra/Sum.hs
+++ b/src/Plutarch/Extra/Sum.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.Sum (
   PSum (..),

--- a/src/Plutarch/Extra/Tagged.hs
+++ b/src/Plutarch/Extra/Tagged.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE UndecidableInstances #-}
 -- Needed for Tagged instances for PlutusTx stuff
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/src/Plutarch/Extra/These.hs
+++ b/src/Plutarch/Extra/These.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Extra.These (
   -- * Types

--- a/src/Plutarch/Orphans.hs
+++ b/src/Plutarch/Orphans.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE UndecidableInstances #-}
 -- The whole point of this module
 {-# OPTIONS_GHC -Wno-orphans #-}
 


### PR DESCRIPTION
Since we now require `DuplicateRecordFields` and `UndecidableInstances` to be on everywhere, this PR sets them to be always-on, and removes any case of them being on per-module.