### PR TITLE
QuickCheck support for AssetClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,24 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.10.5 -- 2022-10-26
+
+### Added
+
+* Modifier `GenAssetClass` to provide QuickCheck support for `AssetClass`
+
+### Modified
+
+* `plutarch-quickcheck` is now a direct dependency, rather than test only.
+
 ## 3.10.4 -- 2022-10-25
 
-Changes to `Plutarch.Extra.AssetClass`:
+### Changed
 
-* Remove unnecessary `PAsData` wrappers
-* Allow tags of `AssetClass` to be poly-kinded
-* `PlyArg` instance for `AssetClass`
+* `Plutarch.Extra.AssetClass`:
+  * Remove unnecessary `PAsData` wrappers
+  * Allow tags of `AssetClass` to be poly-kinded
+  * `PlyArg` instance for `AssetClass`
 
 ## 3.10.3 -- 2022-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
-## 3.11.1 -- 2022-10-26
+## 3.11.1 -- 2022-10-27
 
 ### Added
 
 * Modifier `GenAssetClass` to provide QuickCheck support for `AssetClass`
+* Helper type `AdaClassPresence` for indicating whether `GenAssetClass` should
+  generate the ADA class or not
 
 ### Modified
 

--- a/flake.lock
+++ b/flake.lock
@@ -4571,11 +4571,11 @@
         "plutarch": "plutarch_4"
       },
       "locked": {
-        "lastModified": 1662396899,
-        "narHash": "sha256-viJ8K/KiIIIZNFMPwTaMCFL0f8Z0NtTtTylvK52ZBfc=",
+        "lastModified": 1666728031,
+        "narHash": "sha256-GNzWr65+elYy9LfvOrRKGOh+fP22zlmWZo2cpEResr0=",
         "owner": "liqwid-labs",
         "repo": "plutarch-quickcheck",
-        "rev": "e68e42f3522e47bd0f2a4dd408adf04ba37e11d3",
+        "rev": "30de433657783a68408cd94fbf1082a385919f47",
         "type": "github"
       },
       "original": {
@@ -4700,11 +4700,11 @@
         "secp256k1-haskell": "secp256k1-haskell_4"
       },
       "locked": {
-        "lastModified": 1660577072,
-        "narHash": "sha256-FGx86CLJbkzHnhkTHKb4P37WZmPIJuO/0PjvK6VMnrE=",
+        "lastModified": 1663242420,
+        "narHash": "sha256-r6UVl3pBdJnectz8NDUexh3rY/4XcEqd9ILU+m/jVH8=",
         "owner": "Plutonomicon",
         "repo": "plutarch-plutus",
-        "rev": "79127ad4379828c525200f5e5173894246fa6566",
+        "rev": "67d38e6e14b762eb5a48b884bb96f89687d1a62d",
         "type": "github"
       },
       "original": {

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.10.3
+version:            3.10.5
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra
@@ -143,9 +143,11 @@ library
     , optics-th
     , plutarch-extra
     , plutarch-numeric
+    , plutarch-quickcheck
     , plutus-core
     , ply-core
     , ply-plutarch
+    , QuickCheck
     , serialise
     , tagged
     , text

--- a/src/Plutarch/Extra/AssetClass.hs
+++ b/src/Plutarch/Extra/AssetClass.hs
@@ -35,7 +35,7 @@ module Plutarch.Extra.AssetClass (
   pviaScottEncoding,
 
   -- * Modifiers for QuickCheck
-  AdaACPresence (..),
+  AdaClassPresence (..),
   GenAssetClass (..),
 ) where
 
@@ -433,7 +433,7 @@ type instance PlyArgOf PAssetClassData = AssetClass
 
  @since 3.11.1
 -}
-data AdaACPresence = WithAdaAC | WithoutAdaAC
+data AdaClassPresence = WithAdaClass | WithoutAdaClass
   deriving stock
     ( -- | @since 3.10.5
       Eq
@@ -450,21 +450,21 @@ data AdaACPresence = WithAdaAC | WithoutAdaAC
 
  The easiest way to use this newtype is by pattern matching:
 
- > forAll arbitrary $ \((GenAssetClass ac) :: GenAssetClass WithAdaAC) -> ...
+ > forAll arbitrary $ \((GenAssetClass ac) :: GenAssetClass WithAdaClass) -> ...
 
  You can also \'re-wrap\' for shrinking:
 
- > shrink (GenAssetClass ac :: GenAssetClass WithAdaAC)
+ > shrink (GenAssetClass ac :: GenAssetClass WithAdaClass)
 
  = Note
 
  Due to limitations in QuickCheck itself, 'GenCurrencySymbol' with the
  'WithAdaSymbol' tag over-represents the ADA symbol. We inherit this behaviour
- on all instances of 'GenAssetClass' with th 'WithAdaAC' tag.
+ on all instances of 'GenAssetClass' with th 'WithAdaClass' tag.
 
  @since 3.11.1
 -}
-newtype GenAssetClass (p :: AdaACPresence) = GenAssetClass AssetClass
+newtype GenAssetClass (p :: AdaClassPresence) = GenAssetClass AssetClass
   deriving
     ( -- | @since 3.10.5
       Eq
@@ -484,7 +484,7 @@ newtype GenAssetClass (p :: AdaACPresence) = GenAssetClass AssetClass
 
  @since 3.11.1
 -}
-instance Arbitrary (GenAssetClass 'WithAdaAC) where
+instance Arbitrary (GenAssetClass 'WithAdaClass) where
   {-# INLINEABLE arbitrary #-}
   arbitrary =
     GenAssetClass <$> do
@@ -510,7 +510,7 @@ instance Arbitrary (GenAssetClass 'WithAdaAC) where
 
  @since 3.11.1
 -}
-instance Arbitrary (GenAssetClass 'WithoutAdaAC) where
+instance Arbitrary (GenAssetClass 'WithoutAdaClass) where
   {-# INLINEABLE arbitrary #-}
   arbitrary =
     GenAssetClass <$> do
@@ -528,7 +528,7 @@ instance Arbitrary (GenAssetClass 'WithoutAdaAC) where
       pure . set #name tn' $ ac
 
 -- | @since 3.11.1
-instance CoArbitrary (GenAssetClass 'WithAdaAC) where
+instance CoArbitrary (GenAssetClass 'WithAdaClass) where
   {-# INLINEABLE coarbitrary #-}
   coarbitrary (GenAssetClass ac) =
     let asGen :: GenCurrencySymbol 'WithAdaSymbol =
@@ -536,7 +536,7 @@ instance CoArbitrary (GenAssetClass 'WithAdaAC) where
      in coarbitrary asGen . coarbitrary (view #name ac)
 
 -- | @since 3.11.1
-instance CoArbitrary (GenAssetClass 'WithoutAdaAC) where
+instance CoArbitrary (GenAssetClass 'WithoutAdaClass) where
   {-# INLINEABLE coarbitrary #-}
   coarbitrary (GenAssetClass ac) =
     let asGen :: GenCurrencySymbol 'WithoutAdaSymbol =
@@ -544,18 +544,18 @@ instance CoArbitrary (GenAssetClass 'WithoutAdaAC) where
      in coarbitrary asGen . coarbitrary (view #name ac)
 
 -- | @since 3.11.1
-instance Function (GenAssetClass 'WithAdaAC) where
+instance Function (GenAssetClass 'WithAdaClass) where
   {-# INLINEABLE function #-}
   function = functionMap into outOf
     where
       into ::
-        GenAssetClass 'WithAdaAC ->
+        GenAssetClass 'WithAdaClass ->
         (GenCurrencySymbol 'WithAdaSymbol, TokenName)
       into (GenAssetClass ac) =
         (GenCurrencySymbol . view #symbol $ ac, view #name ac)
       outOf ::
         (GenCurrencySymbol 'WithAdaSymbol, TokenName) ->
-        GenAssetClass 'WithAdaAC
+        GenAssetClass 'WithAdaClass
       outOf (GenCurrencySymbol sym, tn) =
         GenAssetClass $
           AssetClass
@@ -564,18 +564,18 @@ instance Function (GenAssetClass 'WithAdaAC) where
             }
 
 -- | @since 3.11.1
-instance Function (GenAssetClass 'WithoutAdaAC) where
+instance Function (GenAssetClass 'WithoutAdaClass) where
   {-# INLINEABLE function #-}
   function = functionMap into outOf
     where
       into ::
-        GenAssetClass 'WithoutAdaAC ->
+        GenAssetClass 'WithoutAdaClass ->
         (GenCurrencySymbol 'WithoutAdaSymbol, TokenName)
       into (GenAssetClass ac) =
         (GenCurrencySymbol . view #symbol $ ac, view #name ac)
       outOf ::
         (GenCurrencySymbol 'WithoutAdaSymbol, TokenName) ->
-        GenAssetClass 'WithoutAdaAC
+        GenAssetClass 'WithoutAdaClass
       outOf (GenCurrencySymbol sym, tn) =
         GenAssetClass $
           AssetClass


### PR DESCRIPTION
This adds a modifier newtype, similar to `GenCurrencySymbol`, for QuickCheck support for `AssetClass`. It allows control over whether you want the ADA asset class to be generatable or not.