### PR TITLE
FixedDecimal: Zero-cost conversions and optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
-## 3.12.0 -- 2022-10-26
+## 3.12.1 -- 2022-10-27
+
+### Added
+
+* In `Plutarch.Extra.FixedDecimal`, zero-cost conversions to/from integers:
+  - `toFixedZero`
+  - `fromFixedZero`
+  - `ptoFixedZero`
+  - `pfromFixedZero`
+
+## 3.12.0 -- 2022-10-27
 
 ### Added
 

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.12.0
+version:            3.12.1
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra


### PR DESCRIPTION
Forgot something. Also, most `pconstant` are back in, because type inference made the 10 a `Term`, so the `^` would create Plutarch-level calculations.