### PR TITLE
Fix 113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ### Added
 
+* Module `Plutarch.Extra.Deriving` to house derivation helpers.
 * Derivation helper for `Semigroup` and `Monoid` via `PInner`, along with a
   _very_ prominent warning about potential misuse.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.13.0 -- 2022-10-31
+
+### Added
+
+* Derivation helper for `Semigroup` and `Monoid` via `PInner`, along with a
+  _very_ prominent warning about potential misuse.
+
+### Removed
+
+* Overlapping instances of `Semigroup` and `Monoid` via `PInner`.
+
 ## 3.12.2 -- 2022-10-27
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.12.2
+version:            3.13.0
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -98,6 +98,7 @@ library
     Plutarch.Extra.Compile
     Plutarch.Extra.Const
     Plutarch.Extra.DebuggableScript
+    Plutarch.Extra.Deriving
     Plutarch.Extra.ExchangeRate
     Plutarch.Extra.Field
     Plutarch.Extra.Fixed

--- a/src/Plutarch/Extra/Deriving.hs
+++ b/src/Plutarch/Extra/Deriving.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE QuantifiedConstraints #-}
+
+module Plutarch.Extra.Deriving (
+  FromPInner (..),
+) where
+
+import Data.Coerce (coerce)
+import Data.Semigroup (sconcat, stimes)
+import Plutarch.Unsafe (punsafeDowncast)
+
+{- | Derivation helper to obtain 'Semigroup' and 'Monoid' instances for a type
+ by way of its 'PInner' representation.
+
+ = Important notes
+
+ Do /not/ use this helper for any type @a@ where @'PInner' a ~ a@. This will
+ loop the compiler.
+
+ Furthermore, only use this derivation if 'Semigroup' and 'Monoid' methods
+ cannot produce invalid values of the type being derived for. For example, if
+ '<>' between 'PInner's can produce an invalid value of your type, deriving in
+ this manner will allow such values to exist.
+
+ @since 3.13.0
+-}
+newtype FromPInner (a :: S -> Type) (s :: S)
+  = FromPInner (Term s a)
+
+-- | @since 3.13.0
+instance
+  (PInnerSemigroup a (PInner a)) =>
+  Semigroup (FromPInner a s)
+  where
+  {-# INLINEABLE (<>) #-}
+  FromPInner t <> FromPInner t' = FromPInner . punsafeDowncast $ pto t <> pto t'
+  {-# INLINEABLE stimes #-}
+  stimes reps (FromPInner t) =
+    FromPInner . punsafeDowncast . stimes reps . pto $ t
+  {-# INLINEABLE sconcat #-}
+  sconcat = FromPInner . punsafeDowncast . sconcat . fmap (pto . coerce)
+
+-- | @since 3.13.0
+instance
+  (PInnerMonoid a (PInner a)) =>
+  Monoid (FromPInner a s)
+  where
+  {-# INLINEABLE mempty #-}
+  mempty = FromPInner . punsafeDowncast $ mempty
+
+-- Helpers
+
+-- Class synonym instances to get around the problem described in this issue
+-- here: https://gitlab.haskell.org/ghc/ghc/-/issues/17959
+--
+-- More specifically, if we tried to write:
+--
+-- instance (forall s . Semigroup (Term s (PInner a))) => ...
+--
+-- GHC would reject this. However, using something like
+--
+-- instance (PInnerSemigroup a (PInner a)) => ...
+--
+-- works correctly.
+class
+  (b ~ PInner a, forall (s :: S). Semigroup (Term s b)) =>
+  PInnerSemigroup a b
+
+instance
+  (b ~ PInner a, forall (s :: S). Semigroup (Term s b)) =>
+  PInnerSemigroup a b
+
+class
+  (b ~ PInner a, forall (s :: S). Monoid (Term s b)) =>
+  PInnerMonoid a b
+
+instance
+  (b ~ PInner a, forall (s :: S). Monoid (Term s b)) =>
+  PInnerMonoid a b

--- a/src/Plutarch/Orphans.hs
+++ b/src/Plutarch/Orphans.hs
@@ -9,22 +9,19 @@
 -}
 module Plutarch.Orphans () where
 
-import Control.Composition (on, (.*))
-import Data.Coerce (Coercible, coerce)
-import Data.Ratio (Ratio, denominator, numerator, (%))
-
-import Plutarch.Api.V2 (PDatumHash (PDatumHash), PScriptHash (PScriptHash))
-import Plutarch.Builtin (PIsData (pdataImpl, pfromDataImpl))
-import Plutarch.Extra.TermCont (ptryFromC)
-import Plutarch.TryFrom (PTryFrom (ptryFrom'), PTryFromExcess)
-import Plutarch.Unsafe (punsafeCoerce, punsafeDowncast)
-
 import Codec.Serialise (Serialise, deserialiseOrFail, serialise)
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (parserThrowError)
 import Data.ByteString.Lazy (fromStrict, toStrict)
+import Data.Coerce (Coercible, coerce)
+import Data.Ratio (Ratio, denominator, numerator, (%))
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
+import Plutarch.Api.V2 (PDatumHash (PDatumHash), PScriptHash (PScriptHash))
+import Plutarch.Builtin (PIsData (pdataImpl, pfromDataImpl))
+import Plutarch.Extra.TermCont (ptryFromC)
+import Plutarch.TryFrom (PTryFrom (ptryFrom'), PTryFromExcess)
+import Plutarch.Unsafe (punsafeCoerce)
 
 --------------------------------------------------------------------------------
 
@@ -50,22 +47,6 @@ import PlutusLedgerApi.V2 (
 import PlutusTx (FromData (fromBuiltinData), ToData (toBuiltinData))
 
 newtype Flip f a b = Flip (f b a) deriving stock (Generic)
-
--- | @since 1.3.0
-instance
-  {-# OVERLAPPABLE #-}
-  (Semigroup (Term s a), a ~ PInner b) =>
-  Semigroup (Term s b)
-  where
-  (<>) = punsafeDowncast .* ((<>) `on` punsafeCoerce)
-
--- | @since 1.3.0
-instance
-  {-# OVERLAPPABLE #-}
-  (Monoid (Term s a), a ~ PInner b) =>
-  Monoid (Term s b)
-  where
-  mempty = punsafeDowncast mempty
 
 -- | @since 3.0.3
 instance (PIsData a) => PIsData (PAsData a) where


### PR DESCRIPTION
This fixes #113. We do this in two parts:

* Remove the offending instances;
* Add a derivation helper `FromPInner` with the same derivations.

Furthermore, we add a clear warning about using the derivation helper in the case that triggered the original issue (that is, when `PInner a ~ a`). 

This will remain in draft until each of these is checked for compliance:

- [ ] `agora-pro`
- [ ] `agora`
- [X] [`liqwid-onchain`](https://github.com/Liqwid-Labs/liqwid-onchain/pull/234)
- [X] [`oracle-onchain`](https://github.com/Liqwid-Labs/oracle-onchain/pull/14)