### PR TITLE
Resolve improper use of try prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.13.0 -- 2022-10-31
+
+### Modified
+
+* `pfromInlineDatum` has been renamed `ptryFromInlineDatum`, to match
+  conventions.
+* `ptryFromOutputDatum` has been renamed `pfromOutputDatum`, to match
+  conventions.
+* `pfromOutputDatum` has been renamed `ptryFromOutputDatum`, to match
+  conventions.
+* `pownInput` has been renamed `ptryOwnInput`, to match conventions.
+* `pfromDatumHash` has been renamed `ptryFromDatumHash`, to match conventions.
+* `pownValue` has been renamed `ptryOwnValue`, to match conventions.
+
 ## 3.12.2 -- 2022-10-27
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.12.2
+version:            3.13.0
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra


### PR DESCRIPTION
This aims to correct either improper use, or lack of use, of the `try` prefix on Plutarch functions to indicate partiality. I believe this gets them all.