### PR TITLE
Update liqwid-nix

### DIFF
--- a/bench/sorting/PComparator.hs
+++ b/bench/sorting/PComparator.hs
@@ -102,7 +102,8 @@ pfromOrd2 ::
   Term s (PComparator2 a)
 pfromOrd2 =
   pcon . PComparator2 (phoistAcyclic $ plam (#==)) $
-    phoistAcyclic $ plam (#<=)
+    phoistAcyclic $
+      plam (#<=)
 
 pcompareBy2 ::
   forall (a :: S -> Type) (s :: S).
@@ -176,7 +177,8 @@ pfromOrd3 =
     . PComparator3
       (phoistAcyclic $ plam (#==))
       (phoistAcyclic $ plam (#<=))
-    $ phoistAcyclic $ plam (#<)
+    $ phoistAcyclic
+    $ plam (#<)
 
 pcompareBy3 ::
   forall (a :: S -> Type) (s :: S).

--- a/flake.lock
+++ b/flake.lock
@@ -2764,11 +2764,11 @@
         "nixpkgs-2205": "nixpkgs-2205"
       },
       "locked": {
-        "lastModified": 1660580223,
-        "narHash": "sha256-r1i92rrUjSBdnQZpHLxeCAtVGMHYqKQHm05mzddIte8=",
+        "lastModified": 1666695559,
+        "narHash": "sha256-v8DcNma4hAgLCbPHpsxNYzeMURfbxh20VXfFzUED6bs=",
         "owner": "Liqwid-Labs",
         "repo": "liqwid-nix",
-        "rev": "fa1eeba35b37ac2551a00798dffdf053879699c3",
+        "rev": "7add1f24e9360e96b2bab4a1fc7929d4fa649439",
         "type": "github"
       },
       "original": {
@@ -3616,11 +3616,11 @@
     },
     "nixpkgs-latest": {
       "locked": {
-        "lastModified": 1663696179,
-        "narHash": "sha256-vjsfJKxW+z2t2RrYJ9gs71m48kX97+p+fpCHVmH3xxc=",
+        "lastModified": 1667327275,
+        "narHash": "sha256-zmBIBpHGECLNX58BNH36Sn0o4t4uJjSX9P4ODUDX3zE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4717ad12898f9c36f9b9538da0ca9df175ee05e",
+        "rev": "98c61465b148fb34dd17bc87960d107cf20b2b78",
         "type": "github"
       },
       "original": {

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -42,6 +42,7 @@ common common-lang
     , pprelude
 
   default-extensions:
+    NoFieldSelectors
     NoStarIsType
     BangPatterns
     BinaryLiterals
@@ -71,7 +72,6 @@ common common-lang
     TypeFamilies
     TypeOperators
     UndecidableInstances
-    NoFieldSelectors
 
   default-language:   Haskell2010
 

--- a/src/Plutarch/Extra/Applicative.hs
+++ b/src/Plutarch/Extra/Applicative.hs
@@ -54,31 +54,31 @@ instance PApply PMaybeData where
 
 -- | @since 1.0.0
 instance PApply PList where
-  pliftA2 = phoistAcyclic $
-    pfix
+  pliftA2 = phoistAcyclic
+    $ pfix
       #$ plam
-      $ \self f xs ys -> unTermCont $ do
-        t <- pmatchC (puncons # ys)
-        case t of
-          PNothing -> pure pnil
-          PJust t' -> do
-            PPair thead ttail <- pmatchC t'
-            res <- pletC (pmap # plam (\x -> f # x # thead) # xs)
-            pure $ pconcat # res # (self # f # xs # ttail)
+    $ \self f xs ys -> unTermCont $ do
+      t <- pmatchC (puncons # ys)
+      case t of
+        PNothing -> pure pnil
+        PJust t' -> do
+          PPair thead ttail <- pmatchC t'
+          res <- pletC (pmap # plam (\x -> f # x # thead) # xs)
+          pure $ pconcat # res # (self # f # xs # ttail)
 
 -- | @since 1.0.0
 instance PApply PBuiltinList where
-  pliftA2 = phoistAcyclic $
-    pfix
+  pliftA2 = phoistAcyclic
+    $ pfix
       #$ plam
-      $ \self f xs ys -> unTermCont $ do
-        t <- pmatchC (puncons # ys)
-        case t of
-          PNothing -> pure pnil
-          PJust t' -> do
-            PPair thead ttail <- pmatchC t'
-            res <- pletC (pmap # plam (\x -> f # x # thead) # xs)
-            pure $ pconcat # res # (self # f # xs # ttail)
+    $ \self f xs ys -> unTermCont $ do
+      t <- pmatchC (puncons # ys)
+      case t of
+        PNothing -> pure pnil
+        PJust t' -> do
+          PPair thead ttail <- pmatchC t'
+          res <- pletC (pmap # plam (\x -> f # x # thead) # xs)
+          pure $ pconcat # res # (self # f # xs # ttail)
 
 -- | @since 1.0.0
 instance (forall (s :: S). Semigroup (Term s a)) => PApply (PPair a) where

--- a/src/Plutarch/Extra/AssetClass.hs
+++ b/src/Plutarch/Extra/AssetClass.hs
@@ -321,8 +321,10 @@ passetClassData = phoistAcyclic $
   plam $ \sym tk ->
     mkRecordConstr
       PAssetClassData
-      ( #symbol .= pdata sym
-          .& #name .= pdata tk
+      ( #symbol
+          .= pdata sym
+          .& #name
+          .= pdata tk
       )
 
 -- | @since 3.10.4
@@ -361,8 +363,10 @@ pfromScottEncoding = phoistAcyclic $
     \(PAssetClass sym tk) ->
       mkRecordConstr
         PAssetClassData
-        ( #symbol .= sym
-            .& #name .= tk
+        ( #symbol
+            .= sym
+            .& #name
+            .= tk
         )
 
 {- | Wrap a function using the Scott-encoded 'PAssetClass' to one using the

--- a/src/Plutarch/Extra/ExchangeRate.hs
+++ b/src/Plutarch/Extra/ExchangeRate.hs
@@ -31,12 +31,14 @@ exchangeFromTruncate ::
   forall (a :: Symbol) (b :: Symbol) (s :: S).
   Term
     s
-    ( PTagged (a :> b) PRational :--> PTagged a PInteger
+    ( PTagged (a :> b) PRational
+        :--> PTagged a PInteger
         :--> PTagged b PInteger
     )
 exchangeFromTruncate =
   phoistAcyclic $
-    plam $ \ex x -> ppure #$ mulTruncate # pto ex # pto x
+    plam $
+      \ex x -> ppure #$ mulTruncate # pto ex # pto x
 
 {- | Exchange from  one currency to another, truncating the result
  (inverse direction).
@@ -47,7 +49,8 @@ exchangeToTruncate ::
   forall (a :: Symbol) (b :: Symbol) (s :: S).
   Term
     s
-    ( PTagged (a :> b) PRational :--> PTagged b PInteger
+    ( PTagged (a :> b) PRational
+        :--> PTagged b PInteger
         :--> PTagged a PInteger
     )
 exchangeToTruncate =
@@ -64,7 +67,8 @@ exchangeFrom ::
   forall (a :: Symbol) (b :: Symbol) (s :: S).
   Term
     s
-    ( PTagged (a :> b) PRational :--> PTagged a PInteger
+    ( PTagged (a :> b) PRational
+        :--> PTagged a PInteger
         :--> PTagged b PRational
     )
 exchangeFrom =
@@ -80,7 +84,8 @@ exchangeTo ::
   forall (a :: Symbol) (b :: Symbol) (s :: S).
   Term
     s
-    ( PTagged (a :> b) PRational :--> PTagged b PInteger
+    ( PTagged (a :> b) PRational
+        :--> PTagged b PInteger
         :--> PTagged a PRational
     )
 exchangeTo =

--- a/src/Plutarch/Extra/Fixed.hs
+++ b/src/Plutarch/Extra/Fixed.hs
@@ -63,7 +63,8 @@ instance KnownNat u => PNum (PFixed u) where
   (#*) =
     (pcon . PFixed)
       .* (pflip # pdiv # pconstant (natVal (Proxy @u)) #)
-      .* (#*) `on` punsafeCoerce
+      .* (#*)
+      `on` punsafeCoerce
   pfromInteger = pcon . PFixed . (* pconstant (natVal (Proxy @u))) . pconstant
 
 -- | @since 3.12.0

--- a/src/Plutarch/Extra/FixedDecimal.hs
+++ b/src/Plutarch/Extra/FixedDecimal.hs
@@ -434,7 +434,8 @@ ptoRational ::
   KnownNat exp =>
   Term s (PFixedDecimal exp :--> PRational)
 ptoRational = phoistAcyclic $
-  plam $ \z -> pto z #% pconstant (10 ^ natVal (Proxy @exp))
+  plam $
+    \z -> pto z #% pconstant (10 ^ natVal (Proxy @exp))
 
 {- | Make 'PFixed' from 'PInteger'.
 

--- a/src/Plutarch/Extra/IsData.hs
+++ b/src/Plutarch/Extra/IsData.hs
@@ -151,10 +151,10 @@ type family MatchTypesError (n :: [S -> Type]) (m :: [S -> Type]) (a :: Bool) ::
             ':$$: 'Text "\tMismatch between constituent Haskell and Plutarch types"
             ':$$: 'Text "Constituent Haskell Types: "
             ':$$: 'Text "\t"
-            ':<>: 'ShowType n
+              ':<>: 'ShowType n
             ':$$: 'Text "Constituent Plutarch Types: "
             ':$$: 'Text "\t"
-            ':<>: 'ShowType m
+              ':<>: 'ShowType m
         )
     )
 

--- a/src/Plutarch/Extra/Map.hs
+++ b/src/Plutarch/Extra/Map.hs
@@ -285,7 +285,8 @@ ptryLookup ::
   Term s (k :--> PMap keys k v :--> v)
 ptryLookup = phoistAcyclic $
   plam $ \k kvs ->
-    passertPJust # "plookupPartial: No value found for key."
+    passertPJust
+      # "plookupPartial: No value found for key."
       # (plookup # k # kvs)
 
 {- | Given a 'Foldable' of key-value pairs, construct an unsorted 'PMap'.

--- a/src/Plutarch/Extra/Ord.hs
+++ b/src/Plutarch/Extra/Ord.hs
@@ -236,7 +236,8 @@ pmapComparator = phoistAcyclic $
   plam $ \f cmp ->
     pmatch cmp $ \(PComparator peq ple) ->
       pcon . PComparator (plam $ \x y -> peq # (f # x) # (f # y)) $
-        plam $ \x y -> ple # (f # x) # (f # y)
+        plam $
+          \x y -> ple # (f # x) # (f # y)
 
 {- | Reverses the ordering described by a 'PComparator'.
 

--- a/src/Plutarch/Extra/Rational.hs
+++ b/src/Plutarch/Extra/Rational.hs
@@ -86,7 +86,8 @@ instance PNum PRationalNoReduce where
               PRationalNoReduce $
                 pcon $
                   PRational (xn * pto yd + yn * pto xd) $
-                    punsafeDowncast $ pto xd * pto yd
+                    punsafeDowncast $
+                      pto xd * pto yd
       )
       # x'
       # y'
@@ -102,7 +103,8 @@ instance PNum PRationalNoReduce where
             pcon . PRationalNoReduce $
               pcon $
                 PRational (xn * pto yd - yn * pto xd) $
-                  punsafeDowncast $ pto xd * pto yd
+                  punsafeDowncast $
+                    pto xd * pto yd
       )
       # x'
       # y'
@@ -116,7 +118,8 @@ instance PNum PRationalNoReduce where
             pcon . PRationalNoReduce $
               pcon $
                 PRational (xn * yn) $
-                  punsafeDowncast $ pto xd * pto yd
+                  punsafeDowncast $
+                    pto xd * pto yd
       )
       # x'
       # y'

--- a/src/Plutarch/Extra/ScriptContext.hs
+++ b/src/Plutarch/Extra/ScriptContext.hs
@@ -122,7 +122,8 @@ ptryOwnInput = phoistAcyclic $
 -}
 pisUTXOSpent :: Term s (PTxOutRef :--> PBuiltinList PTxInInfo :--> PBool)
 pisUTXOSpent = phoistAcyclic $
-  plam $ \oref inputs -> pisJust #$ pfindTxInByTxOutRef # oref # inputs
+  plam $
+    \oref inputs -> pisJust #$ pfindTxInByTxOutRef # oref # inputs
 
 {- | Sum of all value at input.
 
@@ -167,15 +168,15 @@ pisTokenSpent =
   plam $ \tokenClass inputs ->
     0
       #< pfoldr @PBuiltinList
-        # plam
-          ( \txInInfo' acc -> unTermCont $ do
-              PTxInInfo txInInfo <- pmatchC txInInfo'
-              PTxOut txOut' <- pmatchC $ pfromData $ pfield @"resolved" # txInInfo
-              let value = pfromData $ pfield @"value" # txOut'
-              pure $ acc + passetClassValueOf # tokenClass # value
-          )
-        # 0
-        # inputs
+      # plam
+        ( \txInInfo' acc -> unTermCont $ do
+            PTxInInfo txInInfo <- pmatchC txInInfo'
+            PTxOut txOut' <- pmatchC $ pfromData $ pfield @"resolved" # txInInfo
+            let value = pfromData $ pfield @"value" # txOut'
+            pure $ acc + passetClassValueOf # tokenClass # value
+        )
+      # 0
+      # inputs
 
 {- | Find the TxInInfo by a TxOutRef.
 
@@ -193,7 +194,7 @@ pfindTxInByTxOutRef = phoistAcyclic $
                 (pcon (PJust r))
                 (pcon PNothing)
         )
-      #$ inputs
+        #$ inputs
 
 {- | Check if a PubKeyHash signs this transaction.
 
@@ -201,7 +202,8 @@ pfindTxInByTxOutRef = phoistAcyclic $
 -}
 ptxSignedBy :: forall (s :: S). Term s (PBuiltinList (PAsData PPubKeyHash) :--> PAsData PPubKeyHash :--> PBool)
 ptxSignedBy = phoistAcyclic $
-  plam $ \sigs sig -> pelem # sig # sigs
+  plam $
+    \sigs sig -> pelem # sig # sigs
 
 {- | Convert a 'PDatum' to the give type @a@.
 
@@ -328,9 +330,11 @@ paddressFromValidatorHash ::
   Term s (PValidatorHash :--> PMaybeData PStakingCredential :--> PAddress)
 paddressFromValidatorHash = plam $ \valHash stakingCred ->
   pcon . PAddress $
-    pdcons # pdata (pcon $ PScriptCredential (pdcons # pdata valHash # pdnil))
-      #$ pdcons # pdata stakingCred
-      #$ pdnil
+    pdcons
+      # pdata (pcon $ PScriptCredential (pdcons # pdata valHash # pdnil))
+        #$ pdcons
+      # pdata stakingCred
+        #$ pdnil
 
 {- | Constuct an address (with a staking credential) from a @PPubKeyHash@
 and maybe a @PStakingCredential
@@ -342,9 +346,11 @@ paddressFromPubKeyHash ::
   Term s (PPubKeyHash :--> PMaybeData PStakingCredential :--> PAddress)
 paddressFromPubKeyHash = plam $ \pkh stakingCred ->
   pcon . PAddress $
-    pdcons # pdata (pcon $ PPubKeyCredential (pdcons # pdata pkh # pdnil))
-      #$ pdcons # pdata stakingCred
-      #$ pdnil
+    pdcons
+      # pdata (pcon $ PPubKeyCredential (pdcons # pdata pkh # pdnil))
+        #$ pdcons
+      # pdata stakingCred
+        #$ pdnil
 
 {- | Get script hash from an Address.
      @since 1.3.0
@@ -361,7 +367,8 @@ pscriptHashFromAddress = phoistAcyclic $
 -}
 pisScriptAddress :: forall (s :: S). Term s (PAddress :--> PBool)
 pisScriptAddress = phoistAcyclic $
-  plam $ \addr -> pnot #$ pisPubKey #$ pfromData $ pfield @"credential" # addr
+  plam $
+    \addr -> pnot #$ pisPubKey #$ pfromData $ pfield @"credential" # addr
 
 {- | Return true if the given credential is a pub-key-hash.
      @since 1.3.0
@@ -388,7 +395,8 @@ pfindOutputsToAddress = phoistAcyclic $
   plam $ \outputs address' -> unTermCont $ do
     address <- pletC $ pdata address'
     pure $
-      pfilter # plam (\txOut -> pfield @"address" # txOut #== address)
+      pfilter
+        # plam (\txOut -> pfield @"address" # txOut #== address)
         # outputs
 
 {- | Find the input being spent in the current transaction.
@@ -419,7 +427,8 @@ pfindOutputsToAddress = phoistAcyclic $
 pfindOwnInput ::
   Term
     s
-    ( PBuiltinList PTxInInfo :--> PTxOutRef
+    ( PBuiltinList PTxInInfo
+        :--> PTxOutRef
         :--> PMaybe PTxInInfo
     )
 pfindOwnInput = phoistAcyclic $

--- a/src/Plutarch/Extra/Traversable.hs
+++ b/src/Plutarch/Extra/Traversable.hs
@@ -135,16 +135,16 @@ instance PTraversable PMaybeData where
 
 -- | @since 1.0.0
 instance PTraversable PList where
-  ptraverse = phoistAcyclic $
-    pfix
+  ptraverse = phoistAcyclic
+    $ pfix
       #$ plam
-      $ \self f xs ->
-        pmatch (puncons # xs) $ \case
-          PNothing -> ppure # pnil
-          PJust t' -> do
-            pmatch t' $ \case
-              PPair thead ttail ->
-                pliftA2 # pcons # (f # thead) # (self # f # ttail)
+    $ \self f xs ->
+      pmatch (puncons # xs) $ \case
+        PNothing -> ppure # pnil
+        PJust t' -> do
+          pmatch t' $ \case
+            PPair thead ttail ->
+              pliftA2 # pcons # (f # thead) # (self # f # ttail)
   ptraverse_ ::
     forall
       (b :: S -> Type)
@@ -174,16 +174,16 @@ instance PTraversable PList where
 
 -- | @since 1.0.0
 instance PTraversable PBuiltinList where
-  ptraverse = phoistAcyclic $
-    pfix
+  ptraverse = phoistAcyclic
+    $ pfix
       #$ plam
-      $ \r f xs ->
-        pmatch (puncons # xs) $ \case
-          PNothing -> ppure # pnil
-          PJust t' -> do
-            pmatch t' $ \case
-              PPair thead ttail ->
-                pliftA2 # pcons # (f # thead) # (r # f # ttail)
+    $ \r f xs ->
+      pmatch (puncons # xs) $ \case
+        PNothing -> ppure # pnil
+        PJust t' -> do
+          pmatch t' $ \case
+            PPair thead ttail ->
+              pliftA2 # pcons # (f # thead) # (r # f # ttail)
   ptraverse_ ::
     forall
       (b :: S -> Type)

--- a/src/Plutarch/Extra/Value.hs
+++ b/src/Plutarch/Extra/Value.hs
@@ -122,7 +122,9 @@ psingleValue ::
   forall (key :: KeyGuarantees) (s :: S).
   Term
     s
-    ( PAsData PCurrencySymbol :--> PAsData PTokenName :--> PInteger
+    ( PAsData PCurrencySymbol
+        :--> PAsData PTokenName
+        :--> PInteger
         :--> PBuiltinPair
               (PAsData PCurrencySymbol)
               (PAsData (PMap key PTokenName PInteger))
@@ -571,8 +573,12 @@ phasOnlyOneTokenOfCurrencySymbol ::
   Term s (PCurrencySymbol :--> PValue keys amounts :--> PBool)
 phasOnlyOneTokenOfCurrencySymbol = phoistAcyclic $
   plam $ \cs vs ->
-    psymbolValueOf # cs # vs #== 1
-      #&& (plength #$ pto $ pto $ pto vs) #== 1
+    psymbolValueOf
+      # cs
+      # vs
+      #== 1
+      #&& (plength #$ pto $ pto $ pto vs)
+      #== 1
 
 {- | Returns 'PTrue' if the argument 'PValue' contains /exactly/
   one token of the argument 'PAssetClass'.
@@ -760,8 +766,10 @@ matchOrTryRec requiredAsset = phoistAcyclic $
     precValue
       ( \self pcurrencySymbol pTokenName pint rest ->
           pif
-            ( pconstantData (view #symbol requiredAsset) #== pcurrencySymbol
-                #&& pconstantData (view #name requiredAsset) #== pTokenName
+            ( pconstantData (view #symbol requiredAsset)
+                #== pcurrencySymbol
+                #&& pconstantData (view #name requiredAsset)
+                #== pTokenName
             )
             -- assetClass found - return its quantity and tail of PValueMap
             (pcon $ PPair pint rest)


### PR DESCRIPTION
This upgrades us to the latest `liqwid-nix`. This requires some reformatting to work, due to both `fourmolu` and `cabal-fmt` being bumped: the change surface thus appears larger than it actually is.