### PR TITLE
inspect and inspects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.14.3 -- 2022-11-09
+
+### Added
+
+* `inspect`, as a convenient combination of `asks` and `view`.
+* `inspects`, as a parallel to `views`.
+
 ## 3.14.2 -- 2022-11-09
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.14.2
+version:            3.14.3
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra
@@ -142,6 +142,7 @@ library
     , deepseq
     , generics-sop
     , lens
+    , mtl
     , optics-core
     , optics-th
     , plutarch-extra

--- a/src/Plutarch/Extra/Optics.hs
+++ b/src/Plutarch/Extra/Optics.hs
@@ -1,12 +1,15 @@
 module Plutarch.Extra.Optics (
   HasLabelledGetters,
+  inspect,
+  inspects,
 ) where
 
+import Control.Monad.Reader (MonadReader, asks)
 import Data.Kind (Constraint)
 import GHC.TypeLits (Symbol)
-import Optics.Getter (A_Getter)
+import Optics.Getter (A_Getter, view, views)
 import Optics.Label (LabelOptic)
-import Optics.Optic (Is)
+import Optics.Optic (Is, Optic')
 
 {- | Describes that a type @s@ has a collection of labelled optics, all of type
  @k@, which is at least a getter. @labels@ describes which optics @s@ must
@@ -28,3 +31,39 @@ type family HasLabelledGetters (k :: Type) (s :: Type) (labels :: [(Symbol, Type
   HasLabelledGetters k s '[] = (k `Is` A_Getter)
   HasLabelledGetters k s ('(sym, t) ': labels) =
     (LabelOptic sym k s s t t, HasLabelledGetters k s labels)
+
+{- | 'view' the 'MonadReader' environment using the provided optic.
+
+ @since 3.14.3
+-}
+{-# INLINEABLE inspect #-}
+inspect ::
+  forall
+    (m :: Type -> Type)
+    (r :: Type)
+    (k :: Type)
+    (is :: [Type])
+    (a :: Type).
+  (MonadReader r m, Is k A_Getter) =>
+  Optic' k is r a ->
+  m a
+inspect opt = asks (view opt)
+
+{- | As 'inspect', but using 'views' instead of 'view'.
+
+ @since 3.14.3
+-}
+{-# INLINEABLE inspects #-}
+inspects ::
+  forall
+    (m :: Type -> Type)
+    (r :: Type)
+    (k :: Type)
+    (is :: [Type])
+    (a :: Type)
+    (b :: Type).
+  (MonadReader r m, Is k A_Getter) =>
+  Optic' k is r a ->
+  (a -> b) ->
+  m b
+inspects opt f = asks (views opt f)


### PR DESCRIPTION
This saves typing time by providing a (highly polymorphic) helper `inspect`, which combines `view` and `asks`. Also provided is `inspects`, which parallels `views`.