### PR TITLE
Conversion utilities for PExtendedAssetClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.14.5 -- 2022-11-10
+
+### Added
+
+* `ptoAssetClass` and `ptoAssetClassData` for converting `PExtendedAssetClass`
+  to `PAssetClass` and `PAssetClassData` respectively.
+
 ## 3.14.4 -- 2022-11-09
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.14.4
+version:            3.14.5
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra


### PR DESCRIPTION
These allow easier conversions to a regular `PAssetClass`, as well as `PAssetClassData`, for compatibility with existing functions.