### PR TITLE
Ply instances for ExtendedAssetClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 * `ptoAssetClass` and `ptoAssetClassData` for converting `PExtendedAssetClass`
   to `PAssetClass` and `PAssetClassData` respectively.
+* `PlyArg` instance for `ExtendedAssetClass`.
+* `PlyArgOf` type instance for `ExtendedAssetClass`.
 
 ## 3.14.4 -- 2022-11-09
 

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.14.5
+version:            3.14.6
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra

--- a/src/Plutarch/Extra/ExtendedAssetClass.hs
+++ b/src/Plutarch/Extra/ExtendedAssetClass.hs
@@ -52,9 +52,13 @@ import Plutarch.Lift (
  )
 import PlutusLedgerApi.V2 (
   CurrencySymbol,
+  Data,
   TokenName,
+  toData,
  )
 import PlutusTx.IsData (makeIsDataIndexed)
+import Ply.Core.Class (PlyArg (UPLCRep, toBuiltinArg, toBuiltinArgData))
+import Ply.Plutarch.Class (PlyArgOf)
 
 {- | An 'AssetClass' whose 'TokenName' may or may not be relevant.
 
@@ -82,6 +86,12 @@ makeIsDataIndexed
   [ ('AnyToken, 0)
   , ('FixedToken, 1)
   ]
+
+-- | @since 3.14.5
+instance PlyArg ExtendedAssetClass where
+  type UPLCRep ExtendedAssetClass = Data
+  toBuiltinArg = toData
+  toBuiltinArgData = toData
 
 -- | @since 3.14.2
 deriving via
@@ -204,6 +214,9 @@ instance DerivePlutusType PExtendedAssetClass where
 -- | @since 3.14.2
 instance PUnsafeLiftDecl PExtendedAssetClass where
   type PLifted PExtendedAssetClass = ExtendedAssetClass
+
+-- | @since 3.14.5
+type instance PlyArgOf PExtendedAssetClass = ExtendedAssetClass
 
 {- | As 'passetClassValueOf', but for 'PExtendedAssetClass'.
 


### PR DESCRIPTION
This gives us instances of `PlyArg` and `PlyArgOf` for compatibility with script exports.