### PR TITLE
Rename conversions to mark them unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.15.0 -- 2022-11-11
+
+### Added
+
+* Explain why `punsafeToAssetClassData` and `punsafeToAssetClass` are dangerous
+  conversions in general.
+
+### Changed
+
+* `ptoAssetClass` and `ptoAssetClassData` renamed to `punsafeToAssetClass` and
+  `punsafeToAssetClassData` respectively.
+
 ## 3.14.5 -- 2022-11-10
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.14.6
+version:            3.15.0
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra

--- a/src/Plutarch/Extra/ExtendedAssetClass.hs
+++ b/src/Plutarch/Extra/ExtendedAssetClass.hs
@@ -14,8 +14,8 @@ module Plutarch.Extra.ExtendedAssetClass (
   -- ** Plutarch
   pextendedAssetClassValueOf,
   peqClasses,
-  ptoAssetClass,
-  ptoAssetClassData,
+  punsafeToAssetClass,
+  punsafeToAssetClassData,
 ) where
 
 import Data.Aeson (
@@ -247,12 +247,26 @@ peqClasses = phoistAcyclic $ plam $ \eac acd ->
 
 {- | Convert to a 'PAssetClass'.
 
- @since 3.14.5
+ = Note
+
+ This is /not/ a safe conversion in general (hence its name). For example:
+
+ > cls = pcon $ PAnyTokenType sym
+ >
+ > passetClassValueOf # (ptoAssetClass cls) #
+ >  pconstant (singleton x "" 1 <> singleton x "a" 1)
+
+ Then @v@ would equal @1@, when it's supposed to be @2@.
+
+ There are some legitimate uses for this conversion (specifically for creating
+ 'Value's), which is why it exists, but it should be used with care.
+
+ @since 3.15.0
 -}
-ptoAssetClass ::
+punsafeToAssetClass ::
   forall (s :: S).
   Term s (PExtendedAssetClass :--> PAssetClass)
-ptoAssetClass = phoistAcyclic $ plam $ \eac ->
+punsafeToAssetClass = phoistAcyclic $ plam $ \eac ->
   pmatch eac $ \case
     PAnyToken t ->
       pcon . PAssetClass (pfield @"_0" # t) . pdata . pconstant $ ""
@@ -260,12 +274,18 @@ ptoAssetClass = phoistAcyclic $ plam $ \eac ->
 
 {- | Convert to a 'PAssetClassData'.
 
- @since 3.14.5
+ = Note
+
+ This is not a safe conversion in general, for the same reasons as
+ 'punsafeToAssetClass'. All caveats on the use of 'punsafeToAssetClass' also
+ apply to this function.
+
+ @since 3.15.0
 -}
-ptoAssetClassData ::
+punsafeToAssetClassData ::
   forall (s :: S).
   Term s (PExtendedAssetClass :--> PAssetClassData)
-ptoAssetClassData = phoistAcyclic $ plam $ \eac ->
+punsafeToAssetClassData = phoistAcyclic $ plam $ \eac ->
   pmatch eac $ \case
     PAnyToken t ->
       pcon

--- a/src/Plutarch/Extra/ExtendedAssetClass.hs
+++ b/src/Plutarch/Extra/ExtendedAssetClass.hs
@@ -253,7 +253,7 @@ peqClasses = phoistAcyclic $ plam $ \eac acd ->
 
  > cls = pcon $ PAnyTokenType sym
  >
- > passetClassValueOf # (ptoAssetClass cls) #
+ > passetClassValueOf # (punsafeToAssetClass cls) #
  >  pconstant (singleton x "" 1 <> singleton x "a" 1)
 
  Then @v@ would equal @1@, when it's supposed to be @2@.


### PR DESCRIPTION
As pointed out by @t1lde, `ptoAssetClass` and `ptoAssetClassData` are inherently unsafe. They have been renamed to `punsafeToAssetClass` and `punsafeToAssetClassData` respectively, and an explanation has been added as to why they're not safe.