### PR TITLE
More ExtendedAssetClass helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 * `extendedAdaClass` and `pextendedAdaClass` constants for convenience.
 * `isExtendedAdaClass` to quickly determine whether we have the ADA extended
-  asset class.
+  asset class, along with its Plutarch equivalent `pisExtendedAdaClass`.
 
 ## 3.15.0 -- 2022-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.15.1 -- 2022-11-14
+
+### Added
+
+* `extendedAdaClass` and `pextendedAdaClass` constants for convenience.
+* `isExtendedAdaClass` to quickly determine whether we have the ADA extended
+  asset class.
+
 ## 3.15.0 -- 2022-11-11
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.15.0
+version:            3.15.1
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra

--- a/src/Plutarch/Extra/ExtendedAssetClass.hs
+++ b/src/Plutarch/Extra/ExtendedAssetClass.hs
@@ -9,7 +9,18 @@ module Plutarch.Extra.ExtendedAssetClass (
   -- ** Plutarch
   PExtendedAssetClass (..),
 
+  -- * Constants
+
+  -- ** Haskell
+  extendedAdaClass,
+
+  -- ** Plutarch
+  pextendedAdaClass,
+
   -- * Functions
+
+  -- ** Haskell
+  isExtendedAdaClass,
 
   -- ** Plutarch
   pextendedAssetClassValueOf,
@@ -28,6 +39,7 @@ import Data.Aeson (
   (.:),
  )
 import Data.Aeson.Encoding (pair)
+import Data.Tagged (unTagged)
 import Data.Text (Text, unpack)
 import Optics.AffineTraversal (An_AffineTraversal, atraversal)
 import Optics.Getter (A_Getter, to, view)
@@ -44,6 +56,7 @@ import Plutarch.Extra.AssetClass (
   AssetClass (AssetClass),
   PAssetClass (PAssetClass),
   PAssetClassData (PAssetClassData),
+  adaClass,
   ptoScottEncoding,
  )
 import Plutarch.Extra.Value (
@@ -311,3 +324,24 @@ punsafeToAssetClassData = phoistAcyclic $ plam $ \eac ->
         . PAssetClassData
         $ pdcons # (pfield @"_0" # t) #$ pdcons # (pdata . pconstant $ "") # pdnil
     PFixedToken t -> pfield @"_0" # t
+
+{- | A 'FixedToken' wrapper around 'adaClass'. Provided mostly for convenience.
+
+ @since 3.15.1
+-}
+extendedAdaClass :: ExtendedAssetClass
+extendedAdaClass = FixedToken . unTagged $ adaClass
+
+{- | Plutarch equivalent to 'extendedAdaClass'.
+
+ @since 3.15.1
+-}
+pextendedAdaClass :: forall (s :: S). Term s PExtendedAssetClass
+pextendedAdaClass = pconstant extendedAdaClass
+
+{- | Verify whether an 'ExtendedAssetClass' is the ADA extended asset class.
+
+ @since 3.15.1
+-}
+isExtendedAdaClass :: ExtendedAssetClass -> Bool
+isExtendedAdaClass = (extendedAdaClass ==)

--- a/src/Plutarch/Extra/ExtendedAssetClass.hs
+++ b/src/Plutarch/Extra/ExtendedAssetClass.hs
@@ -23,6 +23,7 @@ module Plutarch.Extra.ExtendedAssetClass (
   isExtendedAdaClass,
 
   -- ** Plutarch
+  pisExtendedAdaClass,
   pextendedAssetClassValueOf,
   pextendedAssetClassValueOf',
   peqClasses,
@@ -345,3 +346,13 @@ pextendedAdaClass = pconstant extendedAdaClass
 -}
 isExtendedAdaClass :: ExtendedAssetClass -> Bool
 isExtendedAdaClass = (extendedAdaClass ==)
+
+{- | As 'isExtendedAdaClass', but for Plutarch.
+
+ @since 3.15.1
+-}
+pisExtendedAdaClass ::
+  forall (s :: S).
+  Term s (PExtendedAssetClass :--> PBool)
+pisExtendedAdaClass = phoistAcyclic $ plam $ \eac ->
+  eac #== pextendedAdaClass


### PR DESCRIPTION
This adds two constants (for Haskell and Plutarch) representing the ADA asset class, as well as a predicate for verifying whether an arbitrary `ExtendedAssetClass` is the ADA one. This also 'burns in' the decision that the ADA class has a fixed, rather than arbitrary, token name, as per @t1lde's suggestion.