### PR TITLE
HasLabelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.15.2 -- 2022-11-15
+
+### Added
+
+* `HasLabelled`, a generalization of `HasLabelledGetters` allowing for any type
+  of optic.
+
+### Modified
+
+* `HasLabelledGetters` is now a synonym for `HasLabelled A_Getter`.
+* `HasLabelledGetters` is marked `DEPRECATED`, and will be removed in the next
+  major release.
+
 ## 3.15.1 -- 2022-11-14
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.15.1
+version:            3.15.2
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra


### PR DESCRIPTION
Amidst my work on `liqwid-onchain` to use `ExtendedAssetClass`, I found myself needing setter capability. However, `HasLabelledGetters` isn't powerful enough to describe that we have _lenses_ on a particular set of fields, only getters.

This PR provides the ability to 'collectively constrain' any number of fields to any optic of our choice, using a type family `HasLabelled`. Furthermore, we provide a backwards-compatible version of `HasLabelledGetters` based on this new design. This has been marked as deprecated for now, but at least it won't break anything.