### PR TITLE
eqClasses, unsafeToAssetClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.15.3 -- 2022-11-17
+
+### Added
+
+* `eqClasses`, a Haskell equivalent to `peqClasses`.
+* `unsafeToAssetClass`, a Haskell equivalent to `punsafeToAssetClass`.
+
 ## 3.15.2 -- 2022-11-15
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.15.2
+version:            3.15.3
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra


### PR DESCRIPTION
This adds two useful `ExtendedAssetClass` functions. Both were originally defined for Plutarch: these are their Haskell equivalents.