### PR TITLE
Fix Data representation for FixedDecimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.17.0 -- 2022-11-25
+
+### Modified
+
+* `ToData` instance for `FixedDecimal` now also serializes its type-level tag.
+* `FromData` and `UnsafeFromData` instances for `FixedDecimal` now inspect the
+  serialized type-level tag to ensure it matches safely.
+* `PConstantDecl` for `FixedDecimal` and `PUnsafeLiftDecl` for `PFixedDecimal`
+  gain `KnownNat` constraints.
+* `PConstantRepr (FixedDecimal unit)` is now `Data`, and `pconstantFromRepr` and
+  `pconstantToRepr` defer to the `Data` representation.
+
 ## 3.16.0 -- 2022-11-21
 
 ### Added

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.16.0
+version:            3.17.0
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra


### PR DESCRIPTION
Currently, `FixedDecimal` only encodes its numerator, as an `Integer`, when performing `Data` serialization. This is a problem: it is very easy to serialize a `FixedDecimal 9`, then deserialize a `FixedDecimal 2`, which can cause significant problems.

This PR repairs this problem by also serializing the `exp` tag as an `Integer`. `FromData` now checks this tag for consistency. `UnsafeFromData` still ignores it as previous, as (given that it's marked unsafe), we can assume that the user wishes to trade correctness checks for performance.

The `PConstantDecl` and `PUnsafeLiftDecl` instances in the `FixedDecimal` module have been updated appropriately to defer to `Data` encodings, as well as carry extra constraints.