### PR TITLE
Rename utilities in `Plutarch.Extra.Time`. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.18.0 -- 2022-11-30
+
+### Modified
+
+Rename types and functions in module `Plutarch.Extra.Time` in order to avoid
+confusion.
+
+* `PCurrentTime` -> `PFullyBoundedTimeRange`
+* `pcurrentTime` -> `pgetFullyBoundedTimeRange`
+* `currentTime` -> `fullyBoundedTimeRangeFromValidRange`
+* `passertCurrentTime` -> `passertFullyBoundedTimeRange`
+* `pisWithinCurrentTime` -> `pisWithinTimeRange` 
+* `pisCurrentTimeWithin` -> `pisTimeRangeWithin`
+* `pcurrentTimeDuration` -> `ptimeRangeDuration`
+
 ## 3.17.0 -- 2022-11-25
 
 ### Modified

--- a/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            3.17.0
+version:            3.18.0
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra


### PR DESCRIPTION
According to the agora audit team:

```
`PCurrentTime` naming in Liqwid-Plutarch-Extra can be confusing because it refers to the whole transaction validity range. The validity range can be very long with the actual current time somewhere in the long range.
```

The purpose of this pr is to eliminate the possible confusion from the naming scheme and thus doesn't contain any actual code changes.